### PR TITLE
COMP: Fix build against Qt 4.8

### DIFF
--- a/src/PythonQtStdDecorators.cpp
+++ b/src/PythonQtStdDecorators.cpp
@@ -126,15 +126,6 @@ bool PythonQtStdDecorators::disconnect(QObject* sender, const QByteArray& signal
   return r;
 }
 
-#undef emit
-void PythonQtStdDecorators::emit(QObject* sender, const QByteArray& signal, PyObject* arg1 ,PyObject* arg2 ,
-          PyObject* arg3 ,PyObject* arg4 ,PyObject* arg5 ,PyObject* arg6 ,PyObject* arg7 )
-{
-  // TODO xxx
-  // use normal PythonQtSlot calling code, add "allowSignal" to member lookup?!
-}
-#define emit
-
 QObject* PythonQtStdDecorators::parent(QObject* o) {
   return o->parent();
 }

--- a/src/PythonQtStdDecorators.h
+++ b/src/PythonQtStdDecorators.h
@@ -61,11 +61,6 @@ public slots:
   bool connect(QObject* sender, const QByteArray& signal, QObject* receiver, const QByteArray& slot);
   bool disconnect(QObject* sender, const QByteArray& signal, PyObject* callable);
   bool disconnect(QObject* sender, const QByteArray& signal, QObject* receiver, const QByteArray& slot);
-
-#undef emit
-  void emit(QObject* sender, const QByteArray& signal, PyObject* arg1 = NULL,PyObject* arg2 = NULL,
-            PyObject* arg3 = NULL,PyObject* arg4 = NULL,PyObject* arg5 = NULL,PyObject* arg6 = NULL,PyObject* arg7 = NULL);
-#define emit
   
   QObject* parent(QObject* o);
   void setParent(QObject* o, QObject* parent);


### PR DESCRIPTION
This failed to compile in the
precompiled. moc_PythonQtStdDecorators.cpp.  This function seems to be
only stub so removing it.
