### PR TITLE
Fix refcount of PyInt_Type when creating enum wrapper

### DIFF
--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -692,6 +692,7 @@ PyObject* PythonQtPrivate::createNewPythonQtEnumWrapper(const char* enumName, Py
   PyObject* className = PyString_FromString(enumName);
 
   PyObject* baseClasses = PyTuple_New(1);
+  Py_INCREF(&PyInt_Type);
   PyTuple_SET_ITEM(baseClasses, 0, (PyObject*)&PyInt_Type);
 
   PyObject* module = PyObject_GetAttrString(parentObject, "__module__");


### PR DESCRIPTION
This commit increments the refcount of the built-in PyInt_Type instance when creating an enum wrapper. This is necessary because PyTuple_SET_ITEM steals a reference to that instance.

Fixing the refcount prevents a crash when calling Py_Finalize() after PythonQt::cleanup() has been run.
