### PR TITLE
Prevent crash when an object is destroyed after calling PythonQt::cleanup()

### DIFF
--- a/src/PythonQtInstanceWrapper.cpp
+++ b/src/PythonQtInstanceWrapper.cpp
@@ -118,7 +118,9 @@ static void PythonQtInstanceWrapper_deleteObject(PythonQtInstanceWrapper* self, 
 
 static void PythonQtInstanceWrapper_dealloc(PythonQtInstanceWrapper* self)
 {
-  PythonQtInstanceWrapper_deleteObject(self);
+  if (PythonQt::self()) {
+    PythonQtInstanceWrapper_deleteObject(self);
+  }
   self->_obj.~QPointer<QObject>();
   Py_TYPE(self)->tp_free((PyObject*)self);
 }


### PR DESCRIPTION
In certain situations the dealloc callback PythonQtInstanceWrapper_dealloc is called after PythonQt::cleanup() has been run. This can happen when Python destroys objects during
Py_Finalize(). This commit adds a check that PythonQt is still initialized in the dealloc callback.
