### PR TITLE
Add missing refcount decrements when creating wrappers

### DIFF
--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -670,6 +670,7 @@ PythonQtClassWrapper* PythonQtPrivate::createNewPythonQtClassWrapper(PythonQtCla
   // create the new type object by calling the type
   result = (PythonQtClassWrapper *)PyObject_Call((PyObject *)&PythonQtClassWrapper_Type, args, NULL);
 
+  Py_DECREF(moduleName);
   Py_DECREF(baseClasses);
   Py_DECREF(typeDict);
   Py_DECREF(args);
@@ -703,6 +704,7 @@ PyObject* PythonQtPrivate::createNewPythonQtEnumWrapper(const char* enumName, Py
   // create the new int derived type object by calling the core type
   result = PyObject_Call((PyObject *)&PyType_Type, args, NULL);
 
+  Py_DECREF(module);
   Py_DECREF(baseClasses);
   Py_DECREF(typeDict);
   Py_DECREF(args);


### PR DESCRIPTION
PyObject_GetAttrString returns a new reference. PyDict_SetItemString does not steal a reference, so Py_DECREF should be called after PyDict_SetItemString.
