### PR TITLE
Enable "name" property support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,10 @@ project(PythonQt)
 
 find_package(PythonLibs REQUIRED)
 include_directories("${PYTHON_INCLUDE_DIR}")
-add_definitions(-DPYTHONQT_USE_RELEASE_PYTHON_FALLBACK)
+add_definitions(
+  -DPYTHONQT_USE_RELEASE_PYTHON_FALLBACK
+  -DPYTHONQT_SUPPORT_NAME_PROPERTY
+  )
 
 #-----------------------------------------------------------------------------
 # Build options


### PR DESCRIPTION
Prior to commit https://github.com/commontk/PythonQt/commit/9c2e489d734758cd63bb7cbe4a0ed6ae6c6ce228, the "name" property was offered as an alias for the "objectName" property. Now, the alias is a compile-time option that is disabled by default.

This commit enables the "name" property alias to maintain backwards compatibility with earlier versions.
