### PR TITLE
Cherry-picked PythonQt changes from patched-6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,10 @@ project(PythonQt)
 
 find_package(PythonLibs REQUIRED)
 include_directories("${PYTHON_INCLUDE_DIR}")
-add_definitions(-DPYTHONQT_USE_RELEASE_PYTHON_FALLBACK)
+add_definitions(
+  -DPYTHONQT_USE_RELEASE_PYTHON_FALLBACK
+  -DPYTHONQT_SUPPORT_NAME_PROPERTY
+  )
 
 #-----------------------------------------------------------------------------
 # Build options

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Prerequisites
 Build instructions
 ------------------
 
-By default, the `patched-3` version will be checked out.
+By default, the `patched-5` version will be checked out.
 
 ```
 git clone git://github.com/commontk/PythonQt.git
@@ -46,7 +46,9 @@ Available branches
 This repository contains 5 branches:
 
 ### patched-5
-* Based on patched-4 + [r395](http://sourceforge.net/p/pythonqt/code/395/)
+* Based on patched-4 + [r403](http://sourceforge.net/p/pythonqt/code/403/) excluding commit [r397](http://sourceforge.net/p/pythonqt/code/397/)
+* List of bug fixes:
+ * Fix for memory leaks and cleanup crash
 * List of features:
  * CMake:
   * Fix install rules

--- a/generator/abstractmetalang.cpp
+++ b/generator/abstractmetalang.cpp
@@ -696,18 +696,6 @@ QString AbstractMetaFunction::targetLangSignature(bool minimal) const
 
     // Attributes...
     if (!minimal) {
-#if 0 // jambi
-        if (isPublic()) s += "public ";
-        else if (isProtected()) s += "protected ";
-        else if (isPrivate()) s += "private ";
-
-//     if (isNative()) s += "native ";
-//     else
-        if (isFinalInTargetLang()) s += "final ";
-        else if (isAbstract()) s += "abstract ";
-
-        if (isStatic()) s += "static ";
-#endif
         // Return type
         if (type())
             s += type()->name() + " ";

--- a/generator/shellgenerator.cpp
+++ b/generator/shellgenerator.cpp
@@ -297,6 +297,18 @@ bool ShellGenerator::functionHasNonConstReferences(const AbstractMetaFunction* f
   return false;
 }
 
+bool ShellGenerator::functionNeedsNormalWrapperSlot(const AbstractMetaFunction* func, const AbstractMetaClass* currentClass)
+{
+  if (func->isSlot()) {
+    return false;
+  }
+  else if (func->isVirtual()) {
+    return func->declaringClass() == currentClass;
+  } else {
+    return true;
+  }
+}
+
 AbstractMetaFunctionList ShellGenerator::getFunctionsToWrap(const AbstractMetaClass* meta_class)
 {
   AbstractMetaFunctionList functions = meta_class->queryFunctions( 

--- a/generator/shellgenerator.h
+++ b/generator/shellgenerator.h
@@ -77,6 +77,8 @@ public:
 
     bool functionHasNonConstReferences(const AbstractMetaFunction* func);
 
+    bool functionNeedsNormalWrapperSlot(const AbstractMetaFunction* func, const AbstractMetaClass* currentClass);
+
     static QString shellClassName(const AbstractMetaClass *meta_class) {
       return "PythonQtShell_" + meta_class->name();
     }

--- a/generator/shellheadergenerator.cpp
+++ b/generator/shellheadergenerator.cpp
@@ -352,7 +352,7 @@ void ShellHeaderGenerator::write(QTextStream &s, const AbstractMetaClass *meta_c
   AbstractMetaFunctionList functions = getFunctionsToWrap(meta_class);
 
   foreach (const AbstractMetaFunction *function, functions) {
-    if (!function->isSlot()) {
+    if (functionNeedsNormalWrapperSlot(function, meta_class)) {
       // for debugging:
       //functionHasNonConstReferences(function);
       s << "   ";

--- a/generator/shellheadergenerator.h
+++ b/generator/shellheadergenerator.h
@@ -60,6 +60,9 @@ public:
     virtual QString fileNameForClass(const AbstractMetaClass *cls) const;
 
     void write(QTextStream &s, const AbstractMetaClass *meta_class);
+
+    void writePromoterArgs(AbstractMetaArgumentList &args, QTextStream & s);
+
     void writeInjectedCode(QTextStream &s, const AbstractMetaClass *meta_class, int type, bool recursive = false);
 
   void writeFieldAccessors(QTextStream &s, const AbstractMetaField *field);

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -294,7 +294,8 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
             s << meta_class->qualifiedCppName() << "::";
           }
         } else {
-          if (fun->wasProtected() || (fun->isVirtual() && meta_class->typeEntry()->shouldCreatePromoter())) {
+          if (fun->wasProtected()) {
+            //|| (fun->isVirtual() && meta_class->typeEntry()->shouldCreatePromoter())) {
             s << " (("  << promoterClassName(meta_class) << "*)theWrappedObject)->promoted_";
           } else {
             s << " theWrappedObject->";

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -248,7 +248,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
   // write member functions
   for (int i = 0; i < functions.size(); ++i) {
     AbstractMetaFunction *fun = functions.at(i);
-    bool needsWrapping = (!fun->isSlot() || fun->isVirtual());
+    bool needsWrapping = !fun->isSlot();
     if (!needsWrapping) {
       continue;
     }

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -248,7 +248,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
   // write member functions
   for (int i = 0; i < functions.size(); ++i) {
     AbstractMetaFunction *fun = functions.at(i);
-    bool needsWrapping = !fun->isSlot();
+    bool needsWrapping = functionNeedsNormalWrapperSlot(fun, meta_class);
     if (!needsWrapping) {
       continue;
     }

--- a/generator/typesystem_gui.xml
+++ b/generator/typesystem_gui.xml
@@ -2099,7 +2099,6 @@ PyObject* constScanLine(QImage* image, int line) {
     <modify-function signature="fontMetrics()const" remove="all"/>
     <modify-function signature="sizeHint()const" rename="getSizeHint"/>
     <modify-function signature="minimumSizeHint()const" rename="getMinimumSizeHint"/>
-    <modify-function signature="setVisible(bool)" remove="all"/>
   </object-type>
 
   <object-type name="QMessageBox">

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -880,12 +880,10 @@ QVariant PythonQt::evalScript(PyObject* object, const QString& script, int start
 
 void PythonQt::evalFile(PyObject* module, const QString& filename)
 {
+  // NOTE: error checking is done by parseFile and evalCode
   PythonQtObjectPtr code = parseFile(filename);
-  clearError();
   if (code) {
     evalCode(module, code);
-  } else {
-    handleError();
   }
 }
 

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1389,6 +1389,18 @@ void PythonQtPrivate::removeSignalEmitter(QObject* obj)
   _signalReceivers.remove(obj);
 }
 
+void PythonQt::removeSignalHandlers()
+{
+  QList<PythonQtSignalReceiver*> signalReceivers = _p->_signalReceivers.values();
+
+  // just delete all signal receivers, they will remove themselves via removeSignalEmitter()
+  foreach(PythonQtSignalReceiver* receiver, signalReceivers) {
+    delete receiver;
+  }
+  // just to be sure, clear the receiver map as well
+  _p->_signalReceivers.clear();
+}
+
 namespace
 {
 //! adapted from python source file "pythonrun.c", function "handle_system_exit"

--- a/src/PythonQt.h
+++ b/src/PythonQt.h
@@ -365,6 +365,9 @@ public:
   //! remove a signal handler from the given \c signal of \c obj
   bool removeSignalHandler(QObject* obj, const char* signal, PyObject* receiver);
 
+  //! globally removes all signal handlers (connections between QObjects and Python).
+  void removeSignalHandlers();
+
   //@}
 
   //---------------------------------------------------------------------------

--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -134,6 +134,7 @@ bool PythonQtClassInfo::lookForPropertyAndCache(const char* memberName)
   const char* attributeName = memberName;
   // look for properties
   int i = _meta->indexOfProperty(attributeName);
+#ifdef PYTHONQT_SUPPORT_NAME_PROPERTY
   if (i==-1) {
     // try to map name to objectName
     if (qstrcmp(attributeName, "name")==0) {
@@ -142,6 +143,7 @@ bool PythonQtClassInfo::lookForPropertyAndCache(const char* memberName)
       i = _meta->indexOfProperty(attributeName);
     }
   }
+#endif
   if (i!=-1) {
     PythonQtMemberInfo newInfo(_meta->property(i));
     _cachedMembers.insert(attributeName, newInfo);

--- a/src/PythonQtInstanceWrapper.cpp
+++ b/src/PythonQtInstanceWrapper.cpp
@@ -345,7 +345,14 @@ static PyObject *PythonQtInstanceWrapper_help(PythonQtInstanceWrapper* obj)
 
 PyObject *PythonQtInstanceWrapper_delete(PythonQtInstanceWrapper * self)
 {
-  PythonQtInstanceWrapper_deleteObject(self, true);
+  PythonQtMemberInfo deleteSlot = self->classInfo()->member("py_delete");
+  if (deleteSlot._type == PythonQtMemberInfo::Slot) {
+    // call the py_delete slot instead of internal C++ destructor...
+    PyObject* resultObj = PythonQtSlotFunction_CallImpl(self->classInfo(), self->_obj, deleteSlot._slot, NULL, NULL, self->_wrappedPtr);
+    Py_XDECREF(resultObj);
+  } else {
+    PythonQtInstanceWrapper_deleteObject(self, true);
+  }
   Py_INCREF(Py_None);
   return Py_None;
 }

--- a/src/PythonQtMethodInfo.cpp
+++ b/src/PythonQtMethodInfo.cpp
@@ -401,7 +401,11 @@ QString PythonQtSlotInfo::fullSignature(bool skipReturnValue, int optionalArgsIn
     if (sig.startsWith("new_")) {
       sig = sig.mid(4);
       isConstructor = true;
-    } else if (sig.startsWith("delete_")) {
+    }
+    else if (sig.startsWith("py_q_")) {
+      sig = sig.mid(5);
+    }
+    else if (sig.startsWith("delete_")) {
       sig = sig.mid(7);
       isDestructor = true;
     } else if(sig.startsWith("static_")) {
@@ -471,6 +475,9 @@ QByteArray PythonQtSlotInfo::slotName(bool removeDecorators) const
 {
   QByteArray name = PythonQtUtils::methodName(_meta);
   if (removeDecorators) {
+    if (name.startsWith("py_q_")) {
+      name = name.mid(5);
+    } else 
     if (name.startsWith("static_")) {
       name = name.mid(7);
       int idx = name.indexOf("_");

--- a/src/PythonQtSignalReceiver.cpp
+++ b/src/PythonQtSignalReceiver.cpp
@@ -213,6 +213,7 @@ bool PythonQtSignalReceiver::removeSignalHandler(const char* signal, PyObject* c
     if (callable) {
       while (i.hasNext()) {
         if (i.next().isSame(sigId, callable)) {
+          QMetaObject::disconnect(_obj, sigId, this, i.value().slotId());
           i.remove();
           foundCount++;
           break;
@@ -221,6 +222,7 @@ bool PythonQtSignalReceiver::removeSignalHandler(const char* signal, PyObject* c
     } else {
       while (i.hasNext()) {
         if (i.next().signalId() == sigId) {
+          QMetaObject::disconnect(_obj, sigId, this, i.value().slotId());
           i.remove();
           foundCount++;
         }

--- a/tests/PythonQtTests.cpp
+++ b/tests/PythonQtTests.cpp
@@ -465,9 +465,11 @@ void PythonQtTestApi::initTestCase()
 void PythonQtTestApi::testProperties()
 {
   PythonQtObjectPtr main = PythonQt::self()->getMainModule();
+#ifdef PYTHONQT_SUPPORT_NAME_PROPERTY
   // check for name alias (for backward comp to Qt3)
   main.evalScript("obj.name = 'hello'");
   QVERIFY(QString("hello") == main.getVariable("obj.name").toString());
+#endif
 
   main.evalScript("obj.objectName = 'hello2'");
   QVERIFY(QString("hello2") == main.getVariable("obj.objectName").toString());


### PR DESCRIPTION
As discussed in https://github.com/msmolens/Slicer/commit/c71b66aaf2a5ad41a656342611682afbd5057aff, cherry-picks PythonQt updates from patched-6 excluding c94226af5137babc92301856847603533350730c.

Tested as part of Slicer build on Windows.
