### PR TITLE
Prevent crashes during and after cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,18 @@ if(BUILD_TESTING)
     tests/PythonQtTests.h
     )
 
+  if(PythonQt_Wrap_Qtcore)
+    include_directories(generated_cpp${generated_cpp_suffix})
+
+    list(APPEND test_sources
+      tests/PythonQtTestCleanup.cpp
+      tests/PythonQtTestCleanup.h
+      )
+    QT4_WRAP_CPP(test_sources
+      tests/PythonQtTestCleanup.h
+      )
+  endif()
+
   set_property(SOURCE tests/PythonQtTestMain.cpp PROPERTY COMPILE_DEFINITIONS "main=tests_PythonQtTestMain")
 
   add_executable(PythonQtCppTests ${test_sources})

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1294,6 +1294,10 @@ PythonQtPrivate::PythonQtPrivate()
   _hadError = false;
   _systemExitExceptionHandlerEnabled = false;
   _debugAPI = new PythonQtDebugAPI(this);
+
+  PythonQtConv::global_valueStorage.init();
+  PythonQtConv::global_ptrStorage.init();
+  PythonQtConv::global_variantStorage.init();
 }
 
 void PythonQtPrivate::setupSharedLibrarySuffixes()

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -657,6 +657,7 @@ PythonQtClassWrapper* PythonQtPrivate::createNewPythonQtClassWrapper(PythonQtCla
   PyObject* className = PyString_FromString(pythonClassName.constData());
 
   PyObject* baseClasses = PyTuple_New(1);
+  Py_INCREF(&PythonQtInstanceWrapper_Type);
   PyTuple_SET_ITEM(baseClasses, 0, (PyObject*)&PythonQtInstanceWrapper_Type);
 
   PyObject* typeDict = PyDict_New();
@@ -1611,6 +1612,7 @@ void PythonQt::initPythonQtModule(bool redirectStdOut, const QByteArray& pythonQ
 #endif
   _p->_pythonQtModuleName = name;
   
+  Py_INCREF(&PythonQtBoolResult_Type);
   PyModule_AddObject(_p->pythonQtModule().object(), "BoolResult", (PyObject*)&PythonQtBoolResult_Type);
   PythonQtObjectPtr sys;
   sys.setNewRef(PyImport_ImportModule("sys"));
@@ -1634,7 +1636,9 @@ void PythonQt::initPythonQtModule(bool redirectStdOut, const QByteArray& pythonQ
     Py_ssize_t old_size = PyTuple_Size(old_module_names);
     PyObject *module_names = PyTuple_New(old_size + 1);
     for (Py_ssize_t i = 0; i < old_size; i++) {
-      PyTuple_SetItem(module_names, i, PyTuple_GetItem(old_module_names, i));
+      PyObject *item = PyTuple_GetItem(old_module_names, i);
+      Py_INCREF(item);
+      PyTuple_SetItem(module_names, i, item);
     }
     PyTuple_SetItem(module_names, old_size, PyString_FromString(name.constData()));
     PyModule_AddObject(sys.object(), "builtin_module_names", module_names);

--- a/src/PythonQt.h
+++ b/src/PythonQt.h
@@ -526,7 +526,7 @@ public:
   //@{
 
   //! get access to internal data (should not be used on the public API, but is used by some C functions)
-  static PythonQtPrivate* priv() { return _self->_p; }
+  static PythonQtPrivate* priv() { return _self ? _self->_p : NULL; }
 
   //! clear all NotFound entries on all class infos, to ensure that
   //! newly loaded wrappers can add methods even when the object was wrapped by PythonQt before the wrapper was loaded

--- a/src/PythonQtMisc.h
+++ b/src/PythonQtMisc.h
@@ -76,12 +76,25 @@ public:
   PythonQtValueStorage() {
     _chunkIdx  = 0;
     _chunkOffset = 0;
+    _currentChunk = NULL;
+  };
+
+  //! initialize memory
+  void init() {
+    assert(_currentChunk == NULL);
+    assert(_chunks.isEmpty());
+    _chunkIdx = 0;
+    _chunkOffset = 0;
     _currentChunk = new T[chunkEntries];
     _chunks.append(_currentChunk);
-  };
+  }
 
   //! clear all memory
   void clear() {
+    _chunkIdx = 0;
+    _chunkOffset = 0;
+    _currentChunk = NULL;
+
     T* chunk;
     Q_FOREACH(chunk, _chunks) {
       delete[]chunk;

--- a/src/PythonQtObjectPtr.cpp
+++ b/src/PythonQtObjectPtr.cpp
@@ -49,7 +49,7 @@ PythonQtObjectPtr::PythonQtObjectPtr(PyObject* o)
 
 PythonQtObjectPtr::~PythonQtObjectPtr()
 { 
-  if (_object) Py_DECREF(_object); 
+  if (_object && Py_IsInitialized()) Py_DECREF(_object);
 }
 
 void PythonQtObjectPtr::setNewRef(PyObject* o)

--- a/src/PythonQtSignalReceiver.cpp
+++ b/src/PythonQtSignalReceiver.cpp
@@ -172,7 +172,9 @@ PythonQtSignalReceiver::PythonQtSignalReceiver(QObject* obj):PythonQtSignalRecei
 
 PythonQtSignalReceiver::~PythonQtSignalReceiver()
 {
-  PythonQt::priv()->removeSignalEmitter(_obj);
+  if (PythonQt::priv()) {
+    PythonQt::priv()->removeSignalEmitter(_obj);
+  }
 }
 
 

--- a/tests/PythonQtTestCleanup.cpp
+++ b/tests/PythonQtTestCleanup.cpp
@@ -1,0 +1,69 @@
+#include "PythonQtTestCleanup.h"
+#include "PythonQt.h"
+#include "PythonQt_QtBindings.h"
+
+void PythonQtTestCleanup::initTestCase()
+{
+}
+
+void PythonQtTestCleanup::cleanupTestCase()
+{
+}
+
+void PythonQtTestCleanup::init()
+{
+  // Initialize before each test
+
+  PythonQt::init(PythonQt::IgnoreSiteModule);
+  PythonQt_init_QtBindings();
+
+  _helper = new PythonQtTestCleanupHelper();
+  PythonQtObjectPtr main = PythonQt::self()->getMainModule();
+  PythonQt::self()->addObject(main, "obj", _helper);
+}
+
+void PythonQtTestCleanup::cleanup()
+{
+  // Finalize and cleanup after each test
+
+  PythonQtObjectPtr main = PythonQt::self()->getMainModule();
+  PythonQt::self()->removeVariable(main, "obj");
+  delete _helper;
+  _helper = NULL;
+
+  if (Py_IsInitialized()) {
+    Py_Finalize();
+  }
+
+  PythonQt::cleanup();
+}
+
+void PythonQtTestCleanup::testQtEnum()
+{
+  QVERIFY(_helper->runScript(
+    "import PythonQt.QtCore\n" \
+    "x = PythonQt.QtCore.QFile.ReadOnly\n" \
+    "obj.setPassed()"
+    ));
+}
+
+void PythonQtTestCleanup::testCallQtMethodInDel()
+{
+  QVERIFY(_helper->runScript(
+    "import PythonQt.QtCore\n" \
+    "class TimerWrapper(object):\n" \
+    "  def __init__(self):\n" \
+    "    self.timer = PythonQt.QtCore.QTimer()\n" \
+    "  def __del__(self):\n" \
+    "    self.timer.setSingleShot(True)\n" \
+    "x = TimerWrapper()\n" \
+    "obj.setPassed()\n"
+    ));
+}
+
+bool PythonQtTestCleanupHelper::runScript(const char* script)
+{
+  _passed = false;
+  PyRun_SimpleString(script);
+  return _passed;
+}

--- a/tests/PythonQtTestCleanup.h
+++ b/tests/PythonQtTestCleanup.h
@@ -1,0 +1,45 @@
+#ifndef _PYTHONQTTESTCLEANUP_H
+#define _PYTHONQTTESTCLEANUP_H
+
+#include "PythonQt.h"
+#include <QtTest/QtTest>
+
+class PythonQtTestCleanupHelper;
+
+//! Test PythonQt cleanup and Python interpreter finalization
+class PythonQtTestCleanup : public QObject
+{
+  Q_OBJECT
+
+private Q_SLOTS:
+  void initTestCase();
+  void cleanupTestCase();
+  void init();
+  void cleanup();
+
+  void testQtEnum();
+  void testCallQtMethodInDel();
+
+private:
+  PythonQtTestCleanupHelper* _helper;
+};
+
+//! Test helper class
+class PythonQtTestCleanupHelper : public QObject
+{
+  Q_OBJECT
+public:
+  PythonQtTestCleanupHelper() :
+    _passed(false) {
+  };
+
+  bool runScript(const char* script);
+
+public Q_SLOTS:
+  void setPassed() { _passed = true; }
+
+private:
+  bool _passed;
+};
+
+#endif

--- a/tests/PythonQtTestMain.cpp
+++ b/tests/PythonQtTestMain.cpp
@@ -44,7 +44,7 @@
 
 #include <QApplication>
 
-int main( int argc, char **argv )
+int main(int argc, char *argv[])
 {
   QApplication qapp(argc, argv);
 

--- a/tests/PythonQtTestMain.cpp
+++ b/tests/PythonQtTestMain.cpp
@@ -41,6 +41,7 @@
 
 #include "PythonQt.h"
 #include "PythonQtTests.h"
+#include "PythonQtTestCleanup.h"
 
 #include <QApplication>
 
@@ -59,6 +60,13 @@ int main(int argc, char *argv[])
   failCount += QTest::qExec(&slotCalling, argc, argv);
 
   PythonQt::cleanup();
+
+  if (Py_IsInitialized()) {
+    Py_Finalize();
+  }
+
+  PythonQtTestCleanup cleanup;
+  failCount += QTest::qExec(&cleanup, argc, argv);
 
   if (failCount>0) {
     std::cerr << "Tests failed: " << failCount << std::endl;


### PR DESCRIPTION
This commit prevents crashes by handling scenarios such as:
(a) object destruction after the Python interpreter has been finalized
(b) object destruction after cleanup, i.e. the singleton no longer exists

Any usage of a Qt enum demonstrates (a).

One example that demonstrates (b) is a QTimer object which is created with a
QApplication parent. PythonQt::cleanup() is called before the QApplication is
completely destroyed, so the code that handles wrapping the QTimer object must
handle the case when the PythonQt singleton no longer exists.

Based on https://github.com/commontk/PythonQt/commit/e7860427ddb0da2ff269d46431217aa02ccd1a90
