### PR TITLE
Fix PythonQtSignalReceiver crash during cleanup

### DIFF
--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -246,6 +246,10 @@ void PythonQt::init(int flags, const QByteArray& pythonQtModuleName)
 void PythonQt::cleanup()
 {
   if (_self) {
+    // Remove signal handlers in advance, since destroying them calls back into
+    // PythonQt::priv()->removeSignalEmitter()
+    _self->removeSignalHandlers();
+
     delete _self;
     _self = NULL;
   }

--- a/tests/PythonQtTestCleanup.cpp
+++ b/tests/PythonQtTestCleanup.cpp
@@ -26,16 +26,14 @@ void PythonQtTestCleanup::cleanup()
 {
   // Finalize and cleanup after each test
 
-  PythonQtObjectPtr main = PythonQt::self()->getMainModule();
-  PythonQt::self()->removeVariable(main, "obj");
-  delete _helper;
-  _helper = NULL;
-
   if (Py_IsInitialized()) {
     Py_Finalize();
   }
 
   PythonQt::cleanup();
+
+  delete _helper;
+  _helper = NULL;
 }
 
 void PythonQtTestCleanup::testQtEnum()
@@ -59,6 +57,19 @@ void PythonQtTestCleanup::testCallQtMethodInDel()
     "x = TimerWrapper()\n" \
     "obj.setPassed()\n"
     ));
+}
+
+void PythonQtTestCleanup::testSignalReceiverCleanup()
+{
+  PythonQtObjectPtr main = PythonQt::self()->getMainModule();
+
+  // Test that PythonQtSignalReceiver is cleaned up properly,
+  // i.e. PythonQt::cleanup() doesn't segfault
+  main.evalScript(
+    "import PythonQt.QtCore\n" \
+    "timer = PythonQt.QtCore.QTimer(obj)\n" \
+    "timer.connect('destroyed()', obj.onDestroyed)\n" \
+    );
 }
 
 bool PythonQtTestCleanupHelper::runScript(const char* script)

--- a/tests/PythonQtTestCleanup.h
+++ b/tests/PythonQtTestCleanup.h
@@ -19,6 +19,7 @@ private Q_SLOTS:
 
   void testQtEnum();
   void testCallQtMethodInDel();
+  void testSignalReceiverCleanup();
 
 private:
   PythonQtTestCleanupHelper* _helper;
@@ -37,6 +38,7 @@ public:
 
 public Q_SLOTS:
   void setPassed() { _passed = true; }
+  void onDestroyed(QObject *) { }
 
 private:
   bool _passed;


### PR DESCRIPTION
This commit fixes a crash during PythonQt::cleanup(). While destroying the
PythonQtPrivate instance, any remaining PythonQtSignalReceivers that are kept
alive only by their parent object will be destroyed. The crash occurs when
PythonQtSignalReceiver's destructor calls back into
PythonQtPrivate::removeSignalEmitter() when the PythonQtPrivate instance is
mostly destroyed.

Includes test case that crashes without the fix.
