### PR TITLE
Eliminate complex typed static variables

### DIFF
--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -47,8 +47,6 @@
 #include <QMetaObject>
 #include <QMetaEnum>
 
-QHash<QByteArray, int> PythonQtMethodInfo::_parameterTypeDict;
-
 PythonQtClassInfo::PythonQtClassInfo() {
   _meta = NULL;
   _constructors = NULL;

--- a/src/PythonQtClassWrapper.cpp
+++ b/src/PythonQtClassWrapper.cpp
@@ -52,7 +52,7 @@
 static PyObject* PythonQtInstanceWrapper_invert(PythonQtInstanceWrapper* wrapper)
 {
   PyObject* result = NULL;
-  static QByteArray memberName = "__invert__";
+  static const char* memberName = "__invert__";
   PythonQtMemberInfo opSlot = wrapper->classInfo()->member(memberName);
   if (opSlot._type == PythonQtMemberInfo::Slot) {
     result = PythonQtSlotFunction_CallImpl(wrapper->classInfo(), wrapper->_obj, opSlot._slot, NULL, NULL, wrapper->_wrappedPtr);
@@ -63,7 +63,7 @@ static PyObject* PythonQtInstanceWrapper_invert(PythonQtInstanceWrapper* wrapper
 static PyObject* PythonQtInstanceWrapper_negative(PythonQtInstanceWrapper* wrapper)
 {
   PyObject* result = NULL;
-  static QByteArray memberName = "__sub__";
+  static const char* memberName = "__sub__";
   PythonQtMemberInfo opSlot = wrapper->classInfo()->member(memberName);
   if (opSlot._type == PythonQtMemberInfo::Slot) {
     result = PythonQtSlotFunction_CallImpl(wrapper->classInfo(), wrapper->_obj, opSlot._slot, NULL, NULL, wrapper->_wrappedPtr);
@@ -75,7 +75,7 @@ static int PythonQtInstanceWrapper_nonzero(PythonQtInstanceWrapper* wrapper)
 {
   int result = (wrapper->_wrappedPtr == NULL && wrapper->_obj == NULL)?0:1;
   if (result) {
-    static QByteArray memberName = "__nonzero__";
+    static const char* memberName = "__nonzero__";
     PythonQtMemberInfo opSlot = wrapper->classInfo()->member(memberName);
     if (opSlot._type == PythonQtMemberInfo::Slot) {
       PyObject* resultObj = PythonQtSlotFunction_CallImpl(wrapper->classInfo(), wrapper->_obj, opSlot._slot, NULL, NULL, wrapper->_wrappedPtr);
@@ -92,7 +92,7 @@ static Py_ssize_t PythonQtInstanceWrapper_length(PythonQtInstanceWrapper* wrappe
 {
   qint64 result = -1;
   if (wrapper->_wrappedPtr != NULL || wrapper->_obj != NULL) {
-    static QByteArray memberName = "__len__";
+    static const char* memberName = "__len__";
     PythonQtMemberInfo opSlot = wrapper->classInfo()->member(memberName);
     if (opSlot._type == PythonQtMemberInfo::Slot) {
       PyObject* resultObj = PythonQtSlotFunction_CallImpl(wrapper->classInfo(), wrapper->_obj, opSlot._slot, NULL, NULL, wrapper->_wrappedPtr);
@@ -191,15 +191,15 @@ static PyObject* PythonQtInstanceWrapper_mul(PyObject* self, PyObject* other)
 #define BINARY_OP(NAME) \
 static PyObject* PythonQtInstanceWrapper_ ## NAME(PyObject* self, PyObject* other) \
 { \
-  static const QByteArray opName("__" #NAME "__"); \
+  static const const char* opName("__" #NAME "__"); \
   return PythonQtInstanceWrapper_binaryfunc(self, other, opName); \
 }
 
 #define BINARY_OP_INPLACE(NAME) \
   static PyObject* PythonQtInstanceWrapper_i ## NAME(PyObject* self, PyObject* other) \
 { \
-  static const QByteArray opName("__i" #NAME "__"); \
-  static const QByteArray fallbackName("__" #NAME "__"); \
+  static const const char* opName("__i" #NAME "__"); \
+  static const const char* fallbackName("__" #NAME "__"); \
   return PythonQtInstanceWrapper_binaryfunc(self, other, opName, fallbackName); \
 }
 

--- a/src/PythonQtConversion.h
+++ b/src/PythonQtConversion.h
@@ -160,10 +160,10 @@ public:
   static QString CPPObjectToString(int type, const void* data);
     
   //! register a converter callback from python to cpp for given metatype
-  static void registerPythonToMetaTypeConverter(int metaTypeId, PythonQtConvertPythonToMetaTypeCB* cb) { _pythonToMetaTypeConverters.insert(metaTypeId, cb); }
+  static void registerPythonToMetaTypeConverter(int metaTypeId, PythonQtConvertPythonToMetaTypeCB* cb) { GetPythonToMetaTypeConverters()->insert(metaTypeId, cb); }
 
   //! register a converter callback from cpp to python for given metatype
-  static void registerMetaTypeToPythonConverter(int metaTypeId, PythonQtConvertMetaTypeToPythonCB* cb) { _metaTypeToPythonConverters.insert(metaTypeId, cb); }
+  static void registerMetaTypeToPythonConverter(int metaTypeId, PythonQtConvertMetaTypeToPythonCB* cb) { GetMetaTypeToPythonConverters()->insert(metaTypeId, cb); }
 
   //! converts the Qt parameter given in \c data, interpreting it as a \c type registered qvariant/meta type, into a Python object,
   static PyObject* convertQtValueToPythonInternal(int type, const void* data);
@@ -187,8 +187,8 @@ public:
   static PythonQtValueStorageWithCleanup<QVariant, 128>  global_variantStorage;
 
 protected:
-  static QHash<int, PythonQtConvertMetaTypeToPythonCB*> _metaTypeToPythonConverters; 
-  static QHash<int, PythonQtConvertPythonToMetaTypeCB*> _pythonToMetaTypeConverters; 
+  static QHash<int, PythonQtConvertMetaTypeToPythonCB*>* GetMetaTypeToPythonConverters(); 
+  static QHash<int, PythonQtConvertPythonToMetaTypeCB*>* GetPythonToMetaTypeConverters(); 
  
   //! handle automatic conversion of some special types (QColor, QBrush, ...)
   static void* handlePythonToQtAutoConversion(int typeId, PyObject* obj, void* alreadyAllocatedCPPObject);

--- a/src/PythonQtImporter.cpp
+++ b/src/PythonQtImporter.cpp
@@ -761,7 +761,7 @@ QString PythonQtImport::replaceExtension(const QString& str, const QString& ext)
 PyObject* PythonQtImport::getCodeFromPyc(const QString& file)
 {
   PyObject* code;
-  const static QString pycStr("pyc");
+  const QString pycStr("pyc");
   QString pyc = replaceExtension(file, pycStr);
   if (PythonQt::importInterface()->exists(pyc)) {
     time_t mtime = 0;

--- a/src/PythonQtInstanceWrapper.cpp
+++ b/src/PythonQtInstanceWrapper.cpp
@@ -248,46 +248,46 @@ static PyObject *PythonQtInstanceWrapper_richcompare(PythonQtInstanceWrapper* wr
     return Py_NotImplemented;
   }
 
-  QByteArray memberName;
+  const char* memberName;
   switch (code) {
   case Py_LT:
     {
-      static QByteArray name = "__lt__";
+      static const char* name = "__lt__";
       memberName = name;
     }
     break;
 
   case Py_LE:
     {
-      static QByteArray name = "__le__";
+      static const char* name = "__le__";
       memberName = name;
     }
     break;
 
   case Py_EQ:
     {
-      static QByteArray name = "__eq__";
+      static const char* name = "__eq__";
       memberName = name;
     }
     break;
 
   case Py_NE:
     {
-      static QByteArray name = "__ne__";
+      static const char* name = "__ne__";
       memberName = name;
     }
     break;
 
   case Py_GT:
     {
-      static QByteArray name = "__gt__";
+      static const char* name = "__gt__";
       memberName = name;
     }
     break;
 
   case Py_GE:
     {
-      static QByteArray name = "__ge__";
+      static const char* name = "__ge__";
       memberName = name;
     }
     break;
@@ -405,7 +405,7 @@ static PyObject *PythonQtInstanceWrapper_getattro(PyObject *obj,PyObject *name)
     }
 
     {
-      static const QByteArray dynamicDictString("py_dynamic_dict");
+      static const char* dynamicDictString("py_dynamic_dict");
       // check for a dynamic dict getter slot
       PythonQtMemberInfo member = wrapper->classInfo()->member(dynamicDictString);
       if (member._type == PythonQtMemberInfo::Slot) {
@@ -490,7 +490,7 @@ static PyObject *PythonQtInstanceWrapper_getattro(PyObject *obj,PyObject *name)
     break;
   case PythonQtMemberInfo::NotFound:
     {
-      static const QByteArray getterString("py_get_");
+      const QByteArray getterString("py_get_");
       // check for a getter slot
       PythonQtMemberInfo member = wrapper->classInfo()->member(getterString + attributeName);
       if (member._type == PythonQtMemberInfo::Slot) {
@@ -498,7 +498,7 @@ static PyObject *PythonQtInstanceWrapper_getattro(PyObject *obj,PyObject *name)
       }
 
       {
-        static const QByteArray dynamicGetterString("py_dynamic_get_attrib");
+        static const char* dynamicGetterString("py_dynamic_get_attrib");
         // check for a dynamic getter slot
         PythonQtMemberInfo member = wrapper->classInfo()->member(dynamicGetterString);
         if (member._type == PythonQtMemberInfo::Slot) {
@@ -625,7 +625,7 @@ static int PythonQtInstanceWrapper_setattro(PyObject *obj,PyObject *name,PyObjec
   }
   else if (member._type == PythonQtMemberInfo::NotFound) {
     // check for a setter slot
-    static const QByteArray setterString("py_set_");
+    const QByteArray setterString("py_set_");
     PythonQtMemberInfo setter = wrapper->classInfo()->member(setterString + attributeName);
     if (setter._type == PythonQtMemberInfo::Slot) {
       // call the setter and ignore the result value

--- a/src/PythonQtMethodInfo.cpp
+++ b/src/PythonQtMethodInfo.cpp
@@ -43,10 +43,6 @@
 #include "PythonQtClassInfo.h"
 #include <iostream>
 
-QHash<QByteArray, PythonQtMethodInfo*> PythonQtMethodInfo::_cachedSignatures;
-QHash<int, PythonQtMethodInfo::ParameterInfo> PythonQtMethodInfo::_cachedParameterInfos;
-QHash<QByteArray, QByteArray> PythonQtMethodInfo::_parameterNameAliases;
-
 PythonQtMethodInfo::PythonQtMethodInfo(const QMetaMethod& meta, PythonQtClassInfo* classInfo)
 {
 #ifdef PYTHONQT_DEBUG
@@ -82,10 +78,10 @@ const PythonQtMethodInfo* PythonQtMethodInfo::getCachedMethodInfo(const QMetaMet
   QByteArray sig(PythonQtUtils::signature(signal));
   sig = sig.mid(sig.indexOf('('));
   QByteArray fullSig = QByteArray(signal.typeName()) + " " + sig;
-  PythonQtMethodInfo* result = _cachedSignatures.value(fullSig);
+  PythonQtMethodInfo* result = getCachedSignatures()->value(fullSig);
   if (!result) {
     result = new PythonQtMethodInfo(signal, classInfo);
-    _cachedSignatures.insert(fullSig, result);
+    getCachedSignatures()->insert(fullSig, result);
   }
   return result;
 }
@@ -105,10 +101,10 @@ const PythonQtMethodInfo* PythonQtMethodInfo::getCachedMethodInfoFromArgumentLis
     arguments << arg;
   }
   fullSig += ")";
-  PythonQtMethodInfo* result = _cachedSignatures.value(fullSig);
+  PythonQtMethodInfo* result = getCachedSignatures()->value(fullSig);
   if (!result) {
     result = new PythonQtMethodInfo(typeName, arguments);
-    _cachedSignatures.insert(fullSig, result);
+    getCachedSignatures()->insert(fullSig, result);
   }
   return result;
 }
@@ -166,7 +162,7 @@ void PythonQtMethodInfo::fillParameterInfo(ParameterInfo& type, const QByteArray
     type.pointerCount = pointerCount;
     type.isReference = hadReference;
 
-    QByteArray alias = _parameterNameAliases.value(name);
+    QByteArray alias = getParameterNameAliases()->value(name);
     if (!alias.isEmpty()) {
       name = alias;
     }
@@ -236,110 +232,110 @@ QByteArray PythonQtMethodInfo::getInnerTemplateTypeName(const QByteArray& typeNa
 
 int PythonQtMethodInfo::nameToType(const char* name)
 {
-  if (_parameterTypeDict.isEmpty()) {
+  if (getParameterTypeDict()->isEmpty()) {
     // we could also use QMetaType::nameToType, but that does a string compare search
     // and does not support QVariant
 
     // QMetaType names
-    _parameterTypeDict.insert("long", QMetaType::Long);
-    _parameterTypeDict.insert("int", QMetaType::Int);
-    _parameterTypeDict.insert("short", QMetaType::Short);
-    _parameterTypeDict.insert("char", QMetaType::Char);
-    _parameterTypeDict.insert("ulong", QMetaType::ULong);
-    _parameterTypeDict.insert("unsigned long", QMetaType::ULong);
-    _parameterTypeDict.insert("uint", QMetaType::UInt);
-    _parameterTypeDict.insert("unsigned int", QMetaType::UInt);
-    _parameterTypeDict.insert("ushort", QMetaType::UShort);
-    _parameterTypeDict.insert("unsigned short", QMetaType::UShort);
-    _parameterTypeDict.insert("uchar", QMetaType::UChar);
-    _parameterTypeDict.insert("unsigned char", QMetaType::UChar);
-    _parameterTypeDict.insert("bool", QMetaType::Bool);
-    _parameterTypeDict.insert("float", QMetaType::Float);
-    _parameterTypeDict.insert("double", QMetaType::Double);
-    _parameterTypeDict.insert("qreal", QMetaType::Double);
-    _parameterTypeDict.insert("QChar", QMetaType::QChar);
-    _parameterTypeDict.insert("QByteArray", QMetaType::QByteArray);
-    _parameterTypeDict.insert("QString", QMetaType::QString);
-    _parameterTypeDict.insert("", QMetaType::Void);
-    _parameterTypeDict.insert("void", QMetaType::Void);
-    _parameterTypeDict.insert("QtMsgType", QMetaType::Int);
+    getParameterTypeDict()->insert("long", QMetaType::Long);
+    getParameterTypeDict()->insert("int", QMetaType::Int);
+    getParameterTypeDict()->insert("short", QMetaType::Short);
+    getParameterTypeDict()->insert("char", QMetaType::Char);
+    getParameterTypeDict()->insert("ulong", QMetaType::ULong);
+    getParameterTypeDict()->insert("unsigned long", QMetaType::ULong);
+    getParameterTypeDict()->insert("uint", QMetaType::UInt);
+    getParameterTypeDict()->insert("unsigned int", QMetaType::UInt);
+    getParameterTypeDict()->insert("ushort", QMetaType::UShort);
+    getParameterTypeDict()->insert("unsigned short", QMetaType::UShort);
+    getParameterTypeDict()->insert("uchar", QMetaType::UChar);
+    getParameterTypeDict()->insert("unsigned char", QMetaType::UChar);
+    getParameterTypeDict()->insert("bool", QMetaType::Bool);
+    getParameterTypeDict()->insert("float", QMetaType::Float);
+    getParameterTypeDict()->insert("double", QMetaType::Double);
+    getParameterTypeDict()->insert("qreal", QMetaType::Double);
+    getParameterTypeDict()->insert("QChar", QMetaType::QChar);
+    getParameterTypeDict()->insert("QByteArray", QMetaType::QByteArray);
+    getParameterTypeDict()->insert("QString", QMetaType::QString);
+    getParameterTypeDict()->insert("", QMetaType::Void);
+    getParameterTypeDict()->insert("void", QMetaType::Void);
+    getParameterTypeDict()->insert("QtMsgType", QMetaType::Int);
 
     // GL types
-    _parameterTypeDict.insert("GLenum", QMetaType::UInt);
-    _parameterTypeDict.insert("GLboolean", QMetaType::UChar);
-    _parameterTypeDict.insert("GLbitfield", QMetaType::UInt);
-    _parameterTypeDict.insert("GLbyte", QMetaType::Char);
-    _parameterTypeDict.insert("GLubyte", QMetaType::UChar);
-    _parameterTypeDict.insert("GLshort", QMetaType::Short);
-    _parameterTypeDict.insert("GLushort", QMetaType::UShort);
-    _parameterTypeDict.insert("GLint", QMetaType::Int);
-    _parameterTypeDict.insert("GLuint", QMetaType::UInt);
-    _parameterTypeDict.insert("GLsizei", QMetaType::UInt);
-    _parameterTypeDict.insert("GLclampf", QMetaType::Float);
-    _parameterTypeDict.insert("GLfloat", QMetaType::Float);
-    _parameterTypeDict.insert("GLclampd", QMetaType::Double);
-    _parameterTypeDict.insert("GLdouble", QMetaType::Double);
-    _parameterTypeDict.insert("GLvoid", QMetaType::Void);
+    getParameterTypeDict()->insert("GLenum", QMetaType::UInt);
+    getParameterTypeDict()->insert("GLboolean", QMetaType::UChar);
+    getParameterTypeDict()->insert("GLbitfield", QMetaType::UInt);
+    getParameterTypeDict()->insert("GLbyte", QMetaType::Char);
+    getParameterTypeDict()->insert("GLubyte", QMetaType::UChar);
+    getParameterTypeDict()->insert("GLshort", QMetaType::Short);
+    getParameterTypeDict()->insert("GLushort", QMetaType::UShort);
+    getParameterTypeDict()->insert("GLint", QMetaType::Int);
+    getParameterTypeDict()->insert("GLuint", QMetaType::UInt);
+    getParameterTypeDict()->insert("GLsizei", QMetaType::UInt);
+    getParameterTypeDict()->insert("GLclampf", QMetaType::Float);
+    getParameterTypeDict()->insert("GLfloat", QMetaType::Float);
+    getParameterTypeDict()->insert("GLclampd", QMetaType::Double);
+    getParameterTypeDict()->insert("GLdouble", QMetaType::Double);
+    getParameterTypeDict()->insert("GLvoid", QMetaType::Void);
     if (QT_POINTER_SIZE == 8) {
-      _parameterTypeDict.insert("qgl_GLintptr", QMetaType::LongLong);
-      _parameterTypeDict.insert("qgl_GLsizeiptr", QMetaType::LongLong);
-      _parameterTypeDict.insert("size_t", QMetaType::ULongLong);
+      getParameterTypeDict()->insert("qgl_GLintptr", QMetaType::LongLong);
+      getParameterTypeDict()->insert("qgl_GLsizeiptr", QMetaType::LongLong);
+      getParameterTypeDict()->insert("size_t", QMetaType::ULongLong);
     } else {
-      _parameterTypeDict.insert("qgl_GLintptr", QMetaType::Int);
-      _parameterTypeDict.insert("qgl_GLsizeiptr", QMetaType::Int);
-      _parameterTypeDict.insert("size_t", QMetaType::UInt);
+      getParameterTypeDict()->insert("qgl_GLintptr", QMetaType::Int);
+      getParameterTypeDict()->insert("qgl_GLsizeiptr", QMetaType::Int);
+      getParameterTypeDict()->insert("size_t", QMetaType::UInt);
     }
 
     // QVariant names
-    _parameterTypeDict.insert("Q_LLONG", QMetaType::LongLong);
-    _parameterTypeDict.insert("Q_ULLONG", QMetaType::ULongLong);
-    _parameterTypeDict.insert("qlonglong", QMetaType::LongLong);
-    _parameterTypeDict.insert("qulonglong", QMetaType::ULongLong);
-    _parameterTypeDict.insert("qint64", QMetaType::LongLong);
-    _parameterTypeDict.insert("quint64", QMetaType::ULongLong);
-    _parameterTypeDict.insert("QVariantHash", QMetaType::QVariantHash);
-    _parameterTypeDict.insert("QVariantMap", QMetaType::QVariantMap);
-    _parameterTypeDict.insert("QVariantList", QMetaType::QVariantList);
-    _parameterTypeDict.insert("QHash<QString,QVariant>", QMetaType::QVariantHash);
-    _parameterTypeDict.insert("QMap<QString,QVariant>", QMetaType::QVariantMap);
-    _parameterTypeDict.insert("QList<QVariant>", QMetaType::QVariantList);
-    _parameterTypeDict.insert("QStringList", QMetaType::QStringList);
-    _parameterTypeDict.insert("QBitArray", QMetaType::QBitArray);
-    _parameterTypeDict.insert("QDate", QMetaType::QDate);
-    _parameterTypeDict.insert("QTime", QMetaType::QTime);
-    _parameterTypeDict.insert("QDateTime", QMetaType::QDateTime);
-    _parameterTypeDict.insert("QUrl", QMetaType::QUrl);
-    _parameterTypeDict.insert("QLocale", QMetaType::QLocale);
-    _parameterTypeDict.insert("QRect", QMetaType::QRect);
-    _parameterTypeDict.insert("QRectF", QMetaType::QRectF);
-    _parameterTypeDict.insert("QSize", QMetaType::QSize);
-    _parameterTypeDict.insert("QSizeF", QMetaType::QSizeF);
-    _parameterTypeDict.insert("QLine", QMetaType::QLine);
-    _parameterTypeDict.insert("QLineF", QMetaType::QLineF);
-    _parameterTypeDict.insert("QPoint", QMetaType::QPoint);
-    _parameterTypeDict.insert("QPointF", QMetaType::QPointF);
-    _parameterTypeDict.insert("QRegExp", QMetaType::QRegExp);
-    _parameterTypeDict.insert("QFont", QMetaType::QFont);
-    _parameterTypeDict.insert("QPixmap", QMetaType::QPixmap);
-    _parameterTypeDict.insert("QBrush", QMetaType::QBrush);
-    _parameterTypeDict.insert("QColor", QMetaType::QColor);
-    _parameterTypeDict.insert("QCursor", QMetaType::QCursor);
-    _parameterTypeDict.insert("QPalette", QMetaType::QPalette);
-    _parameterTypeDict.insert("QIcon", QMetaType::QIcon);
-    _parameterTypeDict.insert("QImage", QMetaType::QImage);
-    _parameterTypeDict.insert("QRegion", QMetaType::QRegion);
-    _parameterTypeDict.insert("QBitmap", QMetaType::QBitmap);
-    _parameterTypeDict.insert("QSizePolicy", QMetaType::QSizePolicy);
-    _parameterTypeDict.insert("QKeySequence", QMetaType::QKeySequence);
-    _parameterTypeDict.insert("QPen", QMetaType::QPen);
-    _parameterTypeDict.insert("QTextLength", QMetaType::QTextLength);
-    _parameterTypeDict.insert("QTextFormat", QMetaType::QTextFormat);
-    _parameterTypeDict.insert("QMatrix", QMetaType::QMatrix);
-    _parameterTypeDict.insert("QVariant", PythonQtMethodInfo::Variant);
+    getParameterTypeDict()->insert("Q_LLONG", QMetaType::LongLong);
+    getParameterTypeDict()->insert("Q_ULLONG", QMetaType::ULongLong);
+    getParameterTypeDict()->insert("qlonglong", QMetaType::LongLong);
+    getParameterTypeDict()->insert("qulonglong", QMetaType::ULongLong);
+    getParameterTypeDict()->insert("qint64", QMetaType::LongLong);
+    getParameterTypeDict()->insert("quint64", QMetaType::ULongLong);
+    getParameterTypeDict()->insert("QVariantHash", QMetaType::QVariantHash);
+    getParameterTypeDict()->insert("QVariantMap", QMetaType::QVariantMap);
+    getParameterTypeDict()->insert("QVariantList", QMetaType::QVariantList);
+    getParameterTypeDict()->insert("QHash<QString,QVariant>", QMetaType::QVariantHash);
+    getParameterTypeDict()->insert("QMap<QString,QVariant>", QMetaType::QVariantMap);
+    getParameterTypeDict()->insert("QList<QVariant>", QMetaType::QVariantList);
+    getParameterTypeDict()->insert("QStringList", QMetaType::QStringList);
+    getParameterTypeDict()->insert("QBitArray", QMetaType::QBitArray);
+    getParameterTypeDict()->insert("QDate", QMetaType::QDate);
+    getParameterTypeDict()->insert("QTime", QMetaType::QTime);
+    getParameterTypeDict()->insert("QDateTime", QMetaType::QDateTime);
+    getParameterTypeDict()->insert("QUrl", QMetaType::QUrl);
+    getParameterTypeDict()->insert("QLocale", QMetaType::QLocale);
+    getParameterTypeDict()->insert("QRect", QMetaType::QRect);
+    getParameterTypeDict()->insert("QRectF", QMetaType::QRectF);
+    getParameterTypeDict()->insert("QSize", QMetaType::QSize);
+    getParameterTypeDict()->insert("QSizeF", QMetaType::QSizeF);
+    getParameterTypeDict()->insert("QLine", QMetaType::QLine);
+    getParameterTypeDict()->insert("QLineF", QMetaType::QLineF);
+    getParameterTypeDict()->insert("QPoint", QMetaType::QPoint);
+    getParameterTypeDict()->insert("QPointF", QMetaType::QPointF);
+    getParameterTypeDict()->insert("QRegExp", QMetaType::QRegExp);
+    getParameterTypeDict()->insert("QFont", QMetaType::QFont);
+    getParameterTypeDict()->insert("QPixmap", QMetaType::QPixmap);
+    getParameterTypeDict()->insert("QBrush", QMetaType::QBrush);
+    getParameterTypeDict()->insert("QColor", QMetaType::QColor);
+    getParameterTypeDict()->insert("QCursor", QMetaType::QCursor);
+    getParameterTypeDict()->insert("QPalette", QMetaType::QPalette);
+    getParameterTypeDict()->insert("QIcon", QMetaType::QIcon);
+    getParameterTypeDict()->insert("QImage", QMetaType::QImage);
+    getParameterTypeDict()->insert("QRegion", QMetaType::QRegion);
+    getParameterTypeDict()->insert("QBitmap", QMetaType::QBitmap);
+    getParameterTypeDict()->insert("QSizePolicy", QMetaType::QSizePolicy);
+    getParameterTypeDict()->insert("QKeySequence", QMetaType::QKeySequence);
+    getParameterTypeDict()->insert("QPen", QMetaType::QPen);
+    getParameterTypeDict()->insert("QTextLength", QMetaType::QTextLength);
+    getParameterTypeDict()->insert("QTextFormat", QMetaType::QTextFormat);
+    getParameterTypeDict()->insert("QMatrix", QMetaType::QMatrix);
+    getParameterTypeDict()->insert("QVariant", PythonQtMethodInfo::Variant);
     // own special types... (none so far, could be e.g. ObjectList
   }
-  QHash<QByteArray, int>::const_iterator it = _parameterTypeDict.find(name);
-  if (it!=_parameterTypeDict.end()) {
+  QHash<QByteArray, int>::const_iterator it = getParameterTypeDict()->find(name);
+  if (it!=getParameterTypeDict()->end()) {
     return it.value();
   } else {
     return PythonQtMethodInfo::Unknown;
@@ -348,29 +344,29 @@ int PythonQtMethodInfo::nameToType(const char* name)
 
 void PythonQtMethodInfo::cleanupCachedMethodInfos()
 {
-  QHashIterator<QByteArray, PythonQtMethodInfo *> i(_cachedSignatures);
+  QHashIterator<QByteArray, PythonQtMethodInfo *> i(*getCachedSignatures());
   while (i.hasNext()) {
     delete i.next().value();
   }
-  _cachedSignatures.clear();
-  _cachedParameterInfos.clear();
+  getCachedSignatures()->clear();
+  getCachedParameterInfos()->clear();
 }
 
 void PythonQtMethodInfo::addParameterTypeAlias(const QByteArray& alias, const QByteArray& name)
 {
-  _parameterNameAliases.insert(alias, name);
+  getParameterNameAliases()->insert(alias, name);
 }
 
 const PythonQtMethodInfo::ParameterInfo& PythonQtMethodInfo::getParameterInfoForMetaType(int type)
 {
-  QHash<int, ParameterInfo>::ConstIterator it = _cachedParameterInfos.find(type);
-  if (it != _cachedParameterInfos.constEnd()) {
+  QHash<int, ParameterInfo>::ConstIterator it = getCachedParameterInfos()->find(type);
+  if (it != getCachedParameterInfos()->constEnd()) {
     return it.value();
   }
   ParameterInfo info;
   fillParameterInfo(info, QMetaType::typeName(type));
-  _cachedParameterInfos.insert(type, info);
-  return _cachedParameterInfos[type];
+  getCachedParameterInfos()->insert(type, info);
+  return getCachedParameterInfos()->value(type);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -577,4 +573,40 @@ QByteArray PythonQtSlotInfo::getImplementingClassName() const
   } else {
     return _meta.enclosingMetaObject()->className();
   }
+}
+
+QHash<QByteArray, int>* PythonQtMethodInfo::getParameterTypeDict()
+{
+  static QHash<QByteArray, int>* parameterTypeDict = NULL;
+  if (parameterTypeDict == NULL) {
+    parameterTypeDict = new QHash<QByteArray, int>();
+  }
+  return parameterTypeDict;
+}
+
+QHash<QByteArray, QByteArray>* PythonQtMethodInfo::getParameterNameAliases()
+{
+  static QHash<QByteArray, QByteArray>* parameterNameAliases = NULL;
+  if (parameterNameAliases == NULL) {
+    parameterNameAliases = new QHash<QByteArray, QByteArray>();
+  }
+  return parameterNameAliases;
+}
+
+QHash<QByteArray, PythonQtMethodInfo*>* PythonQtMethodInfo::getCachedSignatures()
+{
+  static QHash<QByteArray, PythonQtMethodInfo*>* cachedSignatures = NULL;
+  if (cachedSignatures == NULL) {
+    cachedSignatures = new QHash<QByteArray, PythonQtMethodInfo*>();
+  }
+  return cachedSignatures;
+}
+
+QHash<int, PythonQtMethodInfo::ParameterInfo>* PythonQtMethodInfo::getCachedParameterInfos()
+{
+  static QHash<int, PythonQtMethodInfo::ParameterInfo>* cachedParameterInfos = NULL;
+  if (cachedParameterInfos == NULL) {
+    cachedParameterInfos = new QHash<int, PythonQtMethodInfo::ParameterInfo>();
+  }
+  return cachedParameterInfos;
 }

--- a/src/PythonQtMethodInfo.h
+++ b/src/PythonQtMethodInfo.h
@@ -122,13 +122,13 @@ public:
 
 protected:
 
-  static QHash<QByteArray, int> _parameterTypeDict;
-  static QHash<QByteArray, QByteArray> _parameterNameAliases;
+  static QHash<QByteArray, int>* getParameterTypeDict();
+  static QHash<QByteArray, QByteArray>* getParameterNameAliases();
 
   //! stores the cached signatures of methods to speedup mapping from Qt to Python types
-  static QHash<QByteArray, PythonQtMethodInfo*> _cachedSignatures;
+  static QHash<QByteArray, PythonQtMethodInfo*>* getCachedSignatures();
 
-  static QHash<int, ParameterInfo> _cachedParameterInfos;
+  static QHash<int, ParameterInfo>* getCachedParameterInfos();
 
   QList<ParameterInfo> _parameters;
 };


### PR DESCRIPTION
Complex typed static variables (e.g. maps) in dll-s are to avoid.
On Windows they are not initialised in time (or at all) when the dll
is dynamically loaded. The current use of static QHash data members
results in crash on Windows when the PythonQt.dll is loaded.

See details here:
http://stackoverflow.com/questions/5114683/loading-dll-not-initializing-static-c-classes
