### PR TITLE
Eliminate complex typed static variables

### DIFF
--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -47,8 +47,6 @@
 #include <QMetaObject>
 #include <QMetaEnum>
 
-QHash<QByteArray, int> PythonQtMethodInfo::_parameterTypeDict;
-
 PythonQtClassInfo::PythonQtClassInfo() {
   _meta = NULL;
   _constructors = NULL;

--- a/src/PythonQtConversion.h
+++ b/src/PythonQtConversion.h
@@ -160,10 +160,10 @@ public:
   static QString CPPObjectToString(int type, const void* data);
     
   //! register a converter callback from python to cpp for given metatype
-  static void registerPythonToMetaTypeConverter(int metaTypeId, PythonQtConvertPythonToMetaTypeCB* cb) { _pythonToMetaTypeConverters.insert(metaTypeId, cb); }
+  static void registerPythonToMetaTypeConverter(int metaTypeId, PythonQtConvertPythonToMetaTypeCB* cb) { GetPythonToMetaTypeConverters()->insert(metaTypeId, cb); }
 
   //! register a converter callback from cpp to python for given metatype
-  static void registerMetaTypeToPythonConverter(int metaTypeId, PythonQtConvertMetaTypeToPythonCB* cb) { _metaTypeToPythonConverters.insert(metaTypeId, cb); }
+  static void registerMetaTypeToPythonConverter(int metaTypeId, PythonQtConvertMetaTypeToPythonCB* cb) { GetMetaTypeToPythonConverters()->insert(metaTypeId, cb); }
 
   //! converts the Qt parameter given in \c data, interpreting it as a \c type registered qvariant/meta type, into a Python object,
   static PyObject* convertQtValueToPythonInternal(int type, const void* data);
@@ -187,8 +187,8 @@ public:
   static PythonQtValueStorageWithCleanup<QVariant, 128>  global_variantStorage;
 
 protected:
-  static QHash<int, PythonQtConvertMetaTypeToPythonCB*> _metaTypeToPythonConverters; 
-  static QHash<int, PythonQtConvertPythonToMetaTypeCB*> _pythonToMetaTypeConverters; 
+  static QHash<int, PythonQtConvertMetaTypeToPythonCB*>* GetMetaTypeToPythonConverters();
+  static QHash<int, PythonQtConvertPythonToMetaTypeCB*>* GetPythonToMetaTypeConverters();
  
   //! handle automatic conversion of some special types (QColor, QBrush, ...)
   static void* handlePythonToQtAutoConversion(int typeId, PyObject* obj, void* alreadyAllocatedCPPObject);

--- a/src/PythonQtMethodInfo.cpp
+++ b/src/PythonQtMethodInfo.cpp
@@ -43,10 +43,6 @@
 #include "PythonQtClassInfo.h"
 #include <iostream>
 
-QHash<QByteArray, PythonQtMethodInfo*> PythonQtMethodInfo::_cachedSignatures;
-QHash<int, PythonQtMethodInfo::ParameterInfo> PythonQtMethodInfo::_cachedParameterInfos;
-QHash<QByteArray, QByteArray> PythonQtMethodInfo::_parameterNameAliases;
-
 PythonQtMethodInfo::PythonQtMethodInfo(const QMetaMethod& meta, PythonQtClassInfo* classInfo)
 {
 #ifdef PYTHONQT_DEBUG
@@ -82,10 +78,10 @@ const PythonQtMethodInfo* PythonQtMethodInfo::getCachedMethodInfo(const QMetaMet
   QByteArray sig(PythonQtUtils::signature(signal));
   sig = sig.mid(sig.indexOf('('));
   QByteArray fullSig = QByteArray(signal.typeName()) + " " + sig;
-  PythonQtMethodInfo* result = _cachedSignatures.value(fullSig);
+  PythonQtMethodInfo* result = GetCachedSignatures()->value(fullSig);
   if (!result) {
     result = new PythonQtMethodInfo(signal, classInfo);
-    _cachedSignatures.insert(fullSig, result);
+    GetCachedSignatures()->insert(fullSig, result);
   }
   return result;
 }
@@ -105,10 +101,10 @@ const PythonQtMethodInfo* PythonQtMethodInfo::getCachedMethodInfoFromArgumentLis
     arguments << arg;
   }
   fullSig += ")";
-  PythonQtMethodInfo* result = _cachedSignatures.value(fullSig);
+  PythonQtMethodInfo* result = GetCachedSignatures()->value(fullSig);
   if (!result) {
     result = new PythonQtMethodInfo(typeName, arguments);
-    _cachedSignatures.insert(fullSig, result);
+    GetCachedSignatures()->insert(fullSig, result);
   }
   return result;
 }
@@ -166,7 +162,7 @@ void PythonQtMethodInfo::fillParameterInfo(ParameterInfo& type, const QByteArray
     type.pointerCount = pointerCount;
     type.isReference = hadReference;
 
-    QByteArray alias = _parameterNameAliases.value(name);
+    QByteArray alias = GetParameterNameAliases()->value(name);
     if (!alias.isEmpty()) {
       name = alias;
     }
@@ -236,110 +232,110 @@ QByteArray PythonQtMethodInfo::getInnerTemplateTypeName(const QByteArray& typeNa
 
 int PythonQtMethodInfo::nameToType(const char* name)
 {
-  if (_parameterTypeDict.isEmpty()) {
+  if (GetParameterTypeDict()->isEmpty()) {
     // we could also use QMetaType::nameToType, but that does a string compare search
     // and does not support QVariant
 
     // QMetaType names
-    _parameterTypeDict.insert("long", QMetaType::Long);
-    _parameterTypeDict.insert("int", QMetaType::Int);
-    _parameterTypeDict.insert("short", QMetaType::Short);
-    _parameterTypeDict.insert("char", QMetaType::Char);
-    _parameterTypeDict.insert("ulong", QMetaType::ULong);
-    _parameterTypeDict.insert("unsigned long", QMetaType::ULong);
-    _parameterTypeDict.insert("uint", QMetaType::UInt);
-    _parameterTypeDict.insert("unsigned int", QMetaType::UInt);
-    _parameterTypeDict.insert("ushort", QMetaType::UShort);
-    _parameterTypeDict.insert("unsigned short", QMetaType::UShort);
-    _parameterTypeDict.insert("uchar", QMetaType::UChar);
-    _parameterTypeDict.insert("unsigned char", QMetaType::UChar);
-    _parameterTypeDict.insert("bool", QMetaType::Bool);
-    _parameterTypeDict.insert("float", QMetaType::Float);
-    _parameterTypeDict.insert("double", QMetaType::Double);
-    _parameterTypeDict.insert("qreal", QMetaType::Double);
-    _parameterTypeDict.insert("QChar", QMetaType::QChar);
-    _parameterTypeDict.insert("QByteArray", QMetaType::QByteArray);
-    _parameterTypeDict.insert("QString", QMetaType::QString);
-    _parameterTypeDict.insert("", QMetaType::Void);
-    _parameterTypeDict.insert("void", QMetaType::Void);
-    _parameterTypeDict.insert("QtMsgType", QMetaType::Int);
+    GetParameterTypeDict()->insert("long", QMetaType::Long);
+    GetParameterTypeDict()->insert("int", QMetaType::Int);
+    GetParameterTypeDict()->insert("short", QMetaType::Short);
+    GetParameterTypeDict()->insert("char", QMetaType::Char);
+    GetParameterTypeDict()->insert("ulong", QMetaType::ULong);
+    GetParameterTypeDict()->insert("unsigned long", QMetaType::ULong);
+    GetParameterTypeDict()->insert("uint", QMetaType::UInt);
+    GetParameterTypeDict()->insert("unsigned int", QMetaType::UInt);
+    GetParameterTypeDict()->insert("ushort", QMetaType::UShort);
+    GetParameterTypeDict()->insert("unsigned short", QMetaType::UShort);
+    GetParameterTypeDict()->insert("uchar", QMetaType::UChar);
+    GetParameterTypeDict()->insert("unsigned char", QMetaType::UChar);
+    GetParameterTypeDict()->insert("bool", QMetaType::Bool);
+    GetParameterTypeDict()->insert("float", QMetaType::Float);
+    GetParameterTypeDict()->insert("double", QMetaType::Double);
+    GetParameterTypeDict()->insert("qreal", QMetaType::Double);
+    GetParameterTypeDict()->insert("QChar", QMetaType::QChar);
+    GetParameterTypeDict()->insert("QByteArray", QMetaType::QByteArray);
+    GetParameterTypeDict()->insert("QString", QMetaType::QString);
+    GetParameterTypeDict()->insert("", QMetaType::Void);
+    GetParameterTypeDict()->insert("void", QMetaType::Void);
+    GetParameterTypeDict()->insert("QtMsgType", QMetaType::Int);
 
     // GL types
-    _parameterTypeDict.insert("GLenum", QMetaType::UInt);
-    _parameterTypeDict.insert("GLboolean", QMetaType::UChar);
-    _parameterTypeDict.insert("GLbitfield", QMetaType::UInt);
-    _parameterTypeDict.insert("GLbyte", QMetaType::Char);
-    _parameterTypeDict.insert("GLubyte", QMetaType::UChar);
-    _parameterTypeDict.insert("GLshort", QMetaType::Short);
-    _parameterTypeDict.insert("GLushort", QMetaType::UShort);
-    _parameterTypeDict.insert("GLint", QMetaType::Int);
-    _parameterTypeDict.insert("GLuint", QMetaType::UInt);
-    _parameterTypeDict.insert("GLsizei", QMetaType::UInt);
-    _parameterTypeDict.insert("GLclampf", QMetaType::Float);
-    _parameterTypeDict.insert("GLfloat", QMetaType::Float);
-    _parameterTypeDict.insert("GLclampd", QMetaType::Double);
-    _parameterTypeDict.insert("GLdouble", QMetaType::Double);
-    _parameterTypeDict.insert("GLvoid", QMetaType::Void);
+    GetParameterTypeDict()->insert("GLenum", QMetaType::UInt);
+    GetParameterTypeDict()->insert("GLboolean", QMetaType::UChar);
+    GetParameterTypeDict()->insert("GLbitfield", QMetaType::UInt);
+    GetParameterTypeDict()->insert("GLbyte", QMetaType::Char);
+    GetParameterTypeDict()->insert("GLubyte", QMetaType::UChar);
+    GetParameterTypeDict()->insert("GLshort", QMetaType::Short);
+    GetParameterTypeDict()->insert("GLushort", QMetaType::UShort);
+    GetParameterTypeDict()->insert("GLint", QMetaType::Int);
+    GetParameterTypeDict()->insert("GLuint", QMetaType::UInt);
+    GetParameterTypeDict()->insert("GLsizei", QMetaType::UInt);
+    GetParameterTypeDict()->insert("GLclampf", QMetaType::Float);
+    GetParameterTypeDict()->insert("GLfloat", QMetaType::Float);
+    GetParameterTypeDict()->insert("GLclampd", QMetaType::Double);
+    GetParameterTypeDict()->insert("GLdouble", QMetaType::Double);
+    GetParameterTypeDict()->insert("GLvoid", QMetaType::Void);
     if (QT_POINTER_SIZE == 8) {
-      _parameterTypeDict.insert("qgl_GLintptr", QMetaType::LongLong);
-      _parameterTypeDict.insert("qgl_GLsizeiptr", QMetaType::LongLong);
-      _parameterTypeDict.insert("size_t", QMetaType::ULongLong);
+      GetParameterTypeDict()->insert("qgl_GLintptr", QMetaType::LongLong);
+      GetParameterTypeDict()->insert("qgl_GLsizeiptr", QMetaType::LongLong);
+      GetParameterTypeDict()->insert("size_t", QMetaType::ULongLong);
     } else {
-      _parameterTypeDict.insert("qgl_GLintptr", QMetaType::Int);
-      _parameterTypeDict.insert("qgl_GLsizeiptr", QMetaType::Int);
-      _parameterTypeDict.insert("size_t", QMetaType::UInt);
+      GetParameterTypeDict()->insert("qgl_GLintptr", QMetaType::Int);
+      GetParameterTypeDict()->insert("qgl_GLsizeiptr", QMetaType::Int);
+      GetParameterTypeDict()->insert("size_t", QMetaType::UInt);
     }
 
     // QVariant names
-    _parameterTypeDict.insert("Q_LLONG", QMetaType::LongLong);
-    _parameterTypeDict.insert("Q_ULLONG", QMetaType::ULongLong);
-    _parameterTypeDict.insert("qlonglong", QMetaType::LongLong);
-    _parameterTypeDict.insert("qulonglong", QMetaType::ULongLong);
-    _parameterTypeDict.insert("qint64", QMetaType::LongLong);
-    _parameterTypeDict.insert("quint64", QMetaType::ULongLong);
-    _parameterTypeDict.insert("QVariantHash", QMetaType::QVariantHash);
-    _parameterTypeDict.insert("QVariantMap", QMetaType::QVariantMap);
-    _parameterTypeDict.insert("QVariantList", QMetaType::QVariantList);
-    _parameterTypeDict.insert("QHash<QString,QVariant>", QMetaType::QVariantHash);
-    _parameterTypeDict.insert("QMap<QString,QVariant>", QMetaType::QVariantMap);
-    _parameterTypeDict.insert("QList<QVariant>", QMetaType::QVariantList);
-    _parameterTypeDict.insert("QStringList", QMetaType::QStringList);
-    _parameterTypeDict.insert("QBitArray", QMetaType::QBitArray);
-    _parameterTypeDict.insert("QDate", QMetaType::QDate);
-    _parameterTypeDict.insert("QTime", QMetaType::QTime);
-    _parameterTypeDict.insert("QDateTime", QMetaType::QDateTime);
-    _parameterTypeDict.insert("QUrl", QMetaType::QUrl);
-    _parameterTypeDict.insert("QLocale", QMetaType::QLocale);
-    _parameterTypeDict.insert("QRect", QMetaType::QRect);
-    _parameterTypeDict.insert("QRectF", QMetaType::QRectF);
-    _parameterTypeDict.insert("QSize", QMetaType::QSize);
-    _parameterTypeDict.insert("QSizeF", QMetaType::QSizeF);
-    _parameterTypeDict.insert("QLine", QMetaType::QLine);
-    _parameterTypeDict.insert("QLineF", QMetaType::QLineF);
-    _parameterTypeDict.insert("QPoint", QMetaType::QPoint);
-    _parameterTypeDict.insert("QPointF", QMetaType::QPointF);
-    _parameterTypeDict.insert("QRegExp", QMetaType::QRegExp);
-    _parameterTypeDict.insert("QFont", QMetaType::QFont);
-    _parameterTypeDict.insert("QPixmap", QMetaType::QPixmap);
-    _parameterTypeDict.insert("QBrush", QMetaType::QBrush);
-    _parameterTypeDict.insert("QColor", QMetaType::QColor);
-    _parameterTypeDict.insert("QCursor", QMetaType::QCursor);
-    _parameterTypeDict.insert("QPalette", QMetaType::QPalette);
-    _parameterTypeDict.insert("QIcon", QMetaType::QIcon);
-    _parameterTypeDict.insert("QImage", QMetaType::QImage);
-    _parameterTypeDict.insert("QRegion", QMetaType::QRegion);
-    _parameterTypeDict.insert("QBitmap", QMetaType::QBitmap);
-    _parameterTypeDict.insert("QSizePolicy", QMetaType::QSizePolicy);
-    _parameterTypeDict.insert("QKeySequence", QMetaType::QKeySequence);
-    _parameterTypeDict.insert("QPen", QMetaType::QPen);
-    _parameterTypeDict.insert("QTextLength", QMetaType::QTextLength);
-    _parameterTypeDict.insert("QTextFormat", QMetaType::QTextFormat);
-    _parameterTypeDict.insert("QMatrix", QMetaType::QMatrix);
-    _parameterTypeDict.insert("QVariant", PythonQtMethodInfo::Variant);
+    GetParameterTypeDict()->insert("Q_LLONG", QMetaType::LongLong);
+    GetParameterTypeDict()->insert("Q_ULLONG", QMetaType::ULongLong);
+    GetParameterTypeDict()->insert("qlonglong", QMetaType::LongLong);
+    GetParameterTypeDict()->insert("qulonglong", QMetaType::ULongLong);
+    GetParameterTypeDict()->insert("qint64", QMetaType::LongLong);
+    GetParameterTypeDict()->insert("quint64", QMetaType::ULongLong);
+    GetParameterTypeDict()->insert("QVariantHash", QMetaType::QVariantHash);
+    GetParameterTypeDict()->insert("QVariantMap", QMetaType::QVariantMap);
+    GetParameterTypeDict()->insert("QVariantList", QMetaType::QVariantList);
+    GetParameterTypeDict()->insert("QHash<QString,QVariant>", QMetaType::QVariantHash);
+    GetParameterTypeDict()->insert("QMap<QString,QVariant>", QMetaType::QVariantMap);
+    GetParameterTypeDict()->insert("QList<QVariant>", QMetaType::QVariantList);
+    GetParameterTypeDict()->insert("QStringList", QMetaType::QStringList);
+    GetParameterTypeDict()->insert("QBitArray", QMetaType::QBitArray);
+    GetParameterTypeDict()->insert("QDate", QMetaType::QDate);
+    GetParameterTypeDict()->insert("QTime", QMetaType::QTime);
+    GetParameterTypeDict()->insert("QDateTime", QMetaType::QDateTime);
+    GetParameterTypeDict()->insert("QUrl", QMetaType::QUrl);
+    GetParameterTypeDict()->insert("QLocale", QMetaType::QLocale);
+    GetParameterTypeDict()->insert("QRect", QMetaType::QRect);
+    GetParameterTypeDict()->insert("QRectF", QMetaType::QRectF);
+    GetParameterTypeDict()->insert("QSize", QMetaType::QSize);
+    GetParameterTypeDict()->insert("QSizeF", QMetaType::QSizeF);
+    GetParameterTypeDict()->insert("QLine", QMetaType::QLine);
+    GetParameterTypeDict()->insert("QLineF", QMetaType::QLineF);
+    GetParameterTypeDict()->insert("QPoint", QMetaType::QPoint);
+    GetParameterTypeDict()->insert("QPointF", QMetaType::QPointF);
+    GetParameterTypeDict()->insert("QRegExp", QMetaType::QRegExp);
+    GetParameterTypeDict()->insert("QFont", QMetaType::QFont);
+    GetParameterTypeDict()->insert("QPixmap", QMetaType::QPixmap);
+    GetParameterTypeDict()->insert("QBrush", QMetaType::QBrush);
+    GetParameterTypeDict()->insert("QColor", QMetaType::QColor);
+    GetParameterTypeDict()->insert("QCursor", QMetaType::QCursor);
+    GetParameterTypeDict()->insert("QPalette", QMetaType::QPalette);
+    GetParameterTypeDict()->insert("QIcon", QMetaType::QIcon);
+    GetParameterTypeDict()->insert("QImage", QMetaType::QImage);
+    GetParameterTypeDict()->insert("QRegion", QMetaType::QRegion);
+    GetParameterTypeDict()->insert("QBitmap", QMetaType::QBitmap);
+    GetParameterTypeDict()->insert("QSizePolicy", QMetaType::QSizePolicy);
+    GetParameterTypeDict()->insert("QKeySequence", QMetaType::QKeySequence);
+    GetParameterTypeDict()->insert("QPen", QMetaType::QPen);
+    GetParameterTypeDict()->insert("QTextLength", QMetaType::QTextLength);
+    GetParameterTypeDict()->insert("QTextFormat", QMetaType::QTextFormat);
+    GetParameterTypeDict()->insert("QMatrix", QMetaType::QMatrix);
+    GetParameterTypeDict()->insert("QVariant", PythonQtMethodInfo::Variant);
     // own special types... (none so far, could be e.g. ObjectList
   }
-  QHash<QByteArray, int>::const_iterator it = _parameterTypeDict.find(name);
-  if (it!=_parameterTypeDict.end()) {
+  QHash<QByteArray, int>::const_iterator it = GetParameterTypeDict()->find(name);
+  if (it!=GetParameterTypeDict()->end()) {
     return it.value();
   } else {
     return PythonQtMethodInfo::Unknown;
@@ -348,29 +344,29 @@ int PythonQtMethodInfo::nameToType(const char* name)
 
 void PythonQtMethodInfo::cleanupCachedMethodInfos()
 {
-  QHashIterator<QByteArray, PythonQtMethodInfo *> i(_cachedSignatures);
+  QHashIterator<QByteArray, PythonQtMethodInfo *> i(*GetCachedSignatures());
   while (i.hasNext()) {
     delete i.next().value();
   }
-  _cachedSignatures.clear();
-  _cachedParameterInfos.clear();
+  GetCachedSignatures()->clear();
+  GetCachedParameterInfos()->clear();
 }
 
 void PythonQtMethodInfo::addParameterTypeAlias(const QByteArray& alias, const QByteArray& name)
 {
-  _parameterNameAliases.insert(alias, name);
+  GetParameterNameAliases()->insert(alias, name);
 }
 
 const PythonQtMethodInfo::ParameterInfo& PythonQtMethodInfo::getParameterInfoForMetaType(int type)
 {
-  QHash<int, ParameterInfo>::ConstIterator it = _cachedParameterInfos.find(type);
-  if (it != _cachedParameterInfos.constEnd()) {
+  QHash<int, ParameterInfo>::ConstIterator it = GetCachedParameterInfos()->find(type);
+  if (it != GetCachedParameterInfos()->constEnd()) {
     return it.value();
   }
   ParameterInfo info;
   fillParameterInfo(info, QMetaType::typeName(type));
-  _cachedParameterInfos.insert(type, info);
-  return _cachedParameterInfos[type];
+  GetCachedParameterInfos()->insert(type, info);
+  return GetCachedParameterInfos()->value(type);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -577,4 +573,40 @@ QByteArray PythonQtSlotInfo::getImplementingClassName() const
   } else {
     return _meta.enclosingMetaObject()->className();
   }
+}
+
+QHash<QByteArray, int>* PythonQtMethodInfo::GetParameterTypeDict()
+{
+  static QHash<QByteArray, int>* parameterTypeDict = NULL;
+  if (parameterTypeDict == NULL) {
+    parameterTypeDict = new QHash<QByteArray, int>();
+  }
+  return parameterTypeDict;
+}
+
+QHash<QByteArray, QByteArray>* PythonQtMethodInfo::GetParameterNameAliases()
+{
+  static QHash<QByteArray, QByteArray>* parameterNameAliases = NULL;
+  if (parameterNameAliases == NULL) {
+    parameterNameAliases = new QHash<QByteArray, QByteArray>();
+  }
+  return parameterNameAliases;
+}
+
+QHash<QByteArray, PythonQtMethodInfo*>* PythonQtMethodInfo::GetCachedSignatures()
+{
+  static QHash<QByteArray, PythonQtMethodInfo*>* cachedSignatures = NULL;
+  if (cachedSignatures == NULL) {
+    cachedSignatures = new QHash<QByteArray, PythonQtMethodInfo*>();
+  }
+  return cachedSignatures;
+}
+
+QHash<int, PythonQtMethodInfo::ParameterInfo>* PythonQtMethodInfo::GetCachedParameterInfos()
+{
+  static QHash<int, PythonQtMethodInfo::ParameterInfo>* cachedParameterInfos = NULL;
+  if (cachedParameterInfos == NULL) {
+    cachedParameterInfos = new QHash<int, PythonQtMethodInfo::ParameterInfo>();
+  }
+  return cachedParameterInfos;
 }

--- a/src/PythonQtMethodInfo.h
+++ b/src/PythonQtMethodInfo.h
@@ -122,13 +122,13 @@ public:
 
 protected:
 
-  static QHash<QByteArray, int> _parameterTypeDict;
-  static QHash<QByteArray, QByteArray> _parameterNameAliases;
+  static QHash<QByteArray, int>* GetParameterTypeDict();
+  static QHash<QByteArray, QByteArray>* GetParameterNameAliases();
 
   //! stores the cached signatures of methods to speedup mapping from Qt to Python types
-  static QHash<QByteArray, PythonQtMethodInfo*> _cachedSignatures;
+  static QHash<QByteArray, PythonQtMethodInfo*>* GetCachedSignatures();
 
-  static QHash<int, ParameterInfo> _cachedParameterInfos;
+  static QHash<int, ParameterInfo>* GetCachedParameterInfos();
 
   QList<ParameterInfo> _parameters;
 };


### PR DESCRIPTION
Complex typed static variables (e.g. maps) in dll-s are to avoid.
On Windows they are initialised late when the dll
is being loaded dynamically. The current use of static QHash data members
results in crash on Windows when a PythonQt.dll static function is called from a static initialization code from a dependent library, and PythonQt.dll has not been loaded before, already.

See details here:
http://stackoverflow.com/questions/5114683/loading-dll-not-initializing-static-c-classes
