### PR TITLE
Python qt3 qt56 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,10 @@ if(PythonQt_QT_VERSION MATCHES 5)
     message(FATAL_ERROR "Could not determine Qt binary directory: ${_result} ${QT_BINARY_DIR} ${_error}")
   endif()
 
+  set(QT_LIBRARIES )
   foreach(qtlib ${qtlibs})
        include_directories(${Qt5${qtlib}_INCLUDE_DIRS})
+       list(APPEND QT_LIBRARIES ${Qt5${qtlib}_LIBRARIES})
        add_definitions(${Qt5${qtlib}_DEFINITIONS})
   endforeach()
 
@@ -141,13 +143,12 @@ else()
       set(QT_USE_QT${qtlib_uppercase} ${PythonQt_Wrap_Qt${qtlib}})
     endforeach()
 
+    set(QT_USE_QTTEST ${BUILD_TESTING})
+
     include(${QT_USE_FILE})
   else()
     message(FATAL_ERROR "error: Qt4 was not found on your system. You probably need to set the QT_QMAKE_EXECUTABLE variable")
   endif()
-
-  # Enable QtTest in Qt4 is the option BUILD_TESTING was activated
-  set(QT_USE_QTTEST ${BUILD_TESTING})
 
   #-----------------------------------------------------------------------------
   # The variable "generated_cpp_suffix" allows to conditionnally compile the generated wrappers
@@ -310,7 +311,7 @@ target_link_libraries(PythonQt
               ${PYTHON_LIBRARY}
               ${QT_LIBRARIES}
   )
-
+message(${QT_LIBRARIES})
 #-----------------------------------------------------------------------------
 # Install library (on windows, put the dll in 'bin' and the archive in 'lib')
 
@@ -348,7 +349,7 @@ if(BUILD_TESTING)
   set_property(SOURCE tests/PythonQtTestMain.cpp PROPERTY COMPILE_DEFINITIONS "main=tests_PythonQtTestMain")
 
   add_executable(PythonQtCppTests ${test_sources})
-  target_link_libraries(PythonQtCppTests PythonQt)
+  target_link_libraries(PythonQtCppTests PythonQt ${Qt5Test_LIBRARIES})
 
   add_test(
     NAME tests_PythonQtTestMain

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,12 @@ option(PythonQt_Wrap_QtAll "Make all Qt components available in python" OFF)
 if(PythonQt_QT_VERSION MATCHES 4)
   set(qtlibs core gui network opengl sql svg uitools webkit xml xmlpatterns locale)
 else()
-  set(qtlibs Core Network OpenGL Sql Svg Widgets WebKitWidgets Xml XmlPatterns UiTools)
+  set(qtlibs Core Network OpenGL Sql Svg Widgets Xml XmlPatterns UiTools)
+  find_package(Qt5 ${minimum_required_qt5_version} COMPONENTS Core REQUIRED)
+
+  if(${Qt5Core_VERSION_MINOR} LESS 6)
+    list(APPEND qtlibs WebKitWidgets)
+  endif()
 endif()
 
 if(NOT DEFINED PythonQt_INSTALL_RUNTIME_DIR)
@@ -362,5 +367,4 @@ if(BUILD_TESTING)
     COMMAND ${Slicer_LAUNCH_COMMAND} $<TARGET_FILE:PythonQtCppTests> tests/PythonQtTestMain
     )
 endif()
-
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(CTestUseLaunchers OPTIONAL)
 #----------------------------------------------------------------------------
 # Qt version
 
-set(DESIRED_QT_VERSION 5 CACHE STRING "Pick a version of Qt to use: 4 or 5")
+set(PythonQt_QT_VERSION 5 CACHE STRING "Pick a version of Qt to use: 4 or 5")
 
 set(minimum_required_qt5_version "5.3.0")
 set(minimum_required_qt4_version "4.6.2")
@@ -32,11 +32,12 @@ add_definitions(-DPYTHONQT_USE_RELEASE_PYTHON_FALLBACK)
 # Build options
 option(PythonQt_Wrap_QtAll "Make all Qt components available in python" OFF)
 
-if(DESIRED_QT_VERSION MATCHES 4)
+if(PythonQt_QT_VERSION MATCHES 4)
   set(qtlibs core gui network opengl sql svg uitools webkit xml xmlpatterns locale)
 else()
   set(qtlibs Core Network OpenGL Sql Svg Widgets WebKitWidgets Xml XmlPatterns UiTools)
 endif()
+
 if(NOT DEFINED PythonQt_INSTALL_RUNTIME_DIR)
   set(PythonQt_INSTALL_RUNTIME_DIR bin)
 endif()
@@ -81,7 +82,7 @@ endif()
 #-----------------------------------------------------------------------------
 # Setup Qt
 
-if(DESIRED_QT_VERSION MATCHES 5)
+if(PythonQt_QT_VERSION MATCHES 5)
   find_package(Qt5 ${minimum_required_qt5_version} COMPONENTS ${qtlibs} REQUIRED)
 
   if(Qt5_DIR)
@@ -141,8 +142,8 @@ else()
   # associated with the Qt version being used.
   set(generated_cpp_suffix "_${QT_VERSION_MAJOR}${QT_VERSION_MINOR}")
 
-  # TODO: generated headers for Qt4.8 contains several strange locales that are not available out of the box
-  #       force 4.7
+  # TODO: generated headers for Qt4.8 contains several locales that are not available 
+  #       out of the box -> force 4.7
   if("${generated_cpp_suffix}" STREQUAL "_46" OR "${generated_cpp_suffix}" STREQUAL "_48")
     set(generated_cpp_suffix "_47") # Also use 4.7 wrappers for 4.6.x version
    endif()
@@ -205,7 +206,7 @@ set(headers
     src/PythonQtPythonInclude.h
     src/PythonQtUtils.h
 )
-if(DESIRED_QT_VERSION MATCHES 4)
+if(PythonQt_QT_VERSION MATCHES 4)
   set(sources ${sources} generated_cpp${generated_cpp_suffix}/PythonQt_QtBindings.cpp)
   set(headers ${headers} generated_cpp${generated_cpp_suffix}/PythonQt_QtBindings.h)
 endif()
@@ -261,7 +262,7 @@ set(qrc_sources )
 
 #-----------------------------------------------------------------------------
 # Do wrapping
-if(DESIRED_QT_VERSION MATCHES 4)
+if(PythonQt_QT_VERSION MATCHES 4)
   qt4_wrap_cpp(gen_moc_sources ${moc_sources})
   qt4_wrap_ui(gen_ui_sources ${ui_sources})
   qt4_add_resources(gen_qrc_sources ${qrc_sources})
@@ -333,10 +334,15 @@ if(BUILD_TESTING)
     tests/PythonQtTests.cpp
     tests/PythonQtTests.h
     )
-
-  QT4_WRAP_CPP(test_sources
-    tests/PythonQtTests.h
-    )
+  if(PythonQt_QT_VERSION MATCHES 4)
+    QT4_WRAP_CPP(test_sources
+      tests/PythonQtTests.h
+      )
+  else()
+    QT5_WRAP_CPP(test_sources
+      tests/PythonQtTests.h
+      )
+  endif() 
 
   set_property(SOURCE tests/PythonQtTestMain.cpp PROPERTY COMPILE_DEFINITIONS "main=tests_PythonQtTestMain")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,7 @@ target_link_libraries(PythonQt
               ${PYTHON_LIBRARY}
               ${QT_LIBRARIES}
   )
-message(${QT_LIBRARIES})
+
 #-----------------------------------------------------------------------------
 # Install library (on windows, put the dll in 'bin' and the archive in 'lib')
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,16 @@ cmake_minimum_required(VERSION 2.8)
 project(PythonQt)
 #-----------------------------------------------------------------------------
 
+include(CTestUseLaunchers OPTIONAL)
+
+#----------------------------------------------------------------------------
+# Qt version
+
+set(DESIRED_QT_VERSION 5 CACHE STRING "Pick a version of Qt to use: 4 or 5")
+
+set(minimum_required_qt5_version "5.3.0")
+set(minimum_required_qt4_version "4.6.2")
+
 #-----------------------------------------------------------------------------
 # Python libraries
 
@@ -20,7 +30,13 @@ add_definitions(-DPYTHONQT_USE_RELEASE_PYTHON_FALLBACK)
 
 #-----------------------------------------------------------------------------
 # Build options
+option(PythonQt_Wrap_QtAll "Make all Qt components available in python" OFF)
 
+if(DESIRED_QT_VERSION MATCHES 4)
+  set(qtlibs core gui network opengl sql svg uitools webkit xml xmlpatterns locale)
+else()
+  set(qtlibs Core Network OpenGL Sql Svg Widgets WebKitWidgets Xml XmlPatterns UiTools)
+endif()
 if(NOT DEFINED PythonQt_INSTALL_RUNTIME_DIR)
   set(PythonQt_INSTALL_RUNTIME_DIR bin)
 endif()
@@ -46,7 +62,7 @@ endforeach()
 
 # Force option if it applies
 if(PythonQt_Wrap_QtAll)
-  list(REMOVE_ITEM qtlibs xmlpatterns) # xmlpatterns wrapper does *NOT* build at all :(
+  list(REMOVE_ITEM qtlibs XmlPatterns) # xmlpatterns wrapper does *NOT* build at all :(
   foreach(qtlib ${qtlibs})
     if(NOT ${PythonQt_Wrap_Qt${qtlib}})
       set(PythonQt_Wrap_Qt${qtlib} ON CACHE BOOL "Make all of Qt${qtlib} available in python" FORCE)
@@ -65,42 +81,72 @@ endif()
 #-----------------------------------------------------------------------------
 # Setup Qt
 
-set(minimum_required_qt_version "4.6.2")
+if(DESIRED_QT_VERSION MATCHES 5)
+  find_package(Qt5 ${minimum_required_qt5_version} COMPONENTS ${qtlibs} REQUIRED)
 
-find_package(Qt4)
-
-if(QT4_FOUND)
-
-  set(found_qt_version ${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}.${QT_VERSION_PATCH})
-
-  if(${found_qt_version} VERSION_LESS ${minimum_required_qt_version})
-      message(FATAL_ERROR "error: PythonQt requires Qt >= ${minimum_required_qt_version} -- you cannot use Qt ${found_qt_version}.")
+  if(Qt5_DIR)
+    get_filename_component(_Qt5_DIR "${Qt5_DIR}/../../../" ABSOLUTE)
+    list(FIND CMAKE_PREFIX_PATH "${_Qt5_DIR}" _result)
+    if(_result LESS 0)
+      set(CMAKE_PREFIX_PATH "${_Qt5_DIR};${CMAKE_PREFIX_PATH}" CACHE PATH "" FORCE)
+    endif()
   endif()
 
-  # Enable required qt module
-  foreach(qtlib network opengl sql svg uitools webkit xml xmlpatterns)
-    string(TOUPPER ${qtlib} qtlib_uppercase)
-    if (NOT ${QT_QT${qtlib_uppercase}_FOUND})
-      message(FATAL_ERROR "QT_QT${qtlib_uppercase} *not* FOUND - Try to disable PythonQt_Wrap_Qt${qtlib}")
-    endif()
-    set(QT_USE_QT${qtlib_uppercase} ${PythonQt_Wrap_Qt${qtlib}})
-  endforeach()
+  get_target_property(_qmake_exec Qt5::qmake LOCATION)
+  execute_process(COMMAND ${_qmake_exec} -query QT_INSTALL_BINS
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE QT_BINARY_DIR
+    ERROR_VARIABLE _error
+    )
+  string(STRIP "${QT_BINARY_DIR}" QT_BINARY_DIR)
+  if(_result OR NOT EXISTS "${QT_BINARY_DIR}")
+    message(FATAL_ERROR "Could not determine Qt binary directory: ${_result} ${QT_BINARY_DIR} ${_error}")
+  endif()
 
-  set(QT_USE_QTTEST ${BUILD_TESTING})
+  #-----------------------------------------------------------------------------
+  # The variable "generated_cpp_suffix" allows to conditionnally compile the generated wrappers
+  # associated with the Qt version being used.
+  set(generated_cpp_suffix "_${Qt5Core_VERSION_MAJOR}${Qt5Core_VERSION_MINOR}")
 
-  include(${QT_USE_FILE})
 else()
-  message(FATAL_ERROR "error: Qt4 was not found on your system. You probably need to set the QT_QMAKE_EXECUTABLE variable")
-endif()
+  #-----------------------------------------------------------------------------
+  # Setup Qt4
 
-#-----------------------------------------------------------------------------
-# The variable "generated_cpp_suffix" allows to conditionnally compile the generated wrappers
-# associated with the Qt version being used.
-set(generated_cpp_suffix "_${QT_VERSION_MAJOR}${QT_VERSION_MINOR}")
-if("${generated_cpp_suffix}" STREQUAL "_46")
-  set(generated_cpp_suffix "_47") # Also use 4.7 wrappers for 4.6.x version
-endif()
+  find_package(Qt4)
 
+  if(QT4_FOUND)
+
+    set(found_qt_version ${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}.${QT_VERSION_PATCH})
+
+    if(${found_qt_version} VERSION_LESS ${minimum_required_qt4_version})
+      message(FATAL_ERROR "error: PythonQt requires Qt >= ${minimum_required_qt4_version} -- you cannot use Qt ${found_qt_version}.")
+    endif()
+
+    # Enable required qt module
+    foreach(qtlib network opengl sql svg uitools webkit xml xmlpatterns)
+      string(TOUPPER ${qtlib} qtlib_uppercase)
+      if (NOT ${QT_QT${qtlib_uppercase}_FOUND})
+        message(FATAL_ERROR "QT_QT${${qtlib_uppercase} *not* FOUND - Try to disable PythonQt_Wrap_Qt${qtlib}")
+      endif()
+      set(QT_USE_QT${qtlib_uppercase} ${PythonQt_Wrap_Qt${qtlib}})
+    endforeach()
+
+    include(${QT_USE_FILE})
+  else()
+    message(FATAL_ERROR "error: Qt4 was not found on your system. You probably need to set the QT_QMAKE_EXECUTABLE variable")
+  endif()
+
+  #-----------------------------------------------------------------------------
+  # The variable "generated_cpp_suffix" allows to conditionnally compile the generated wrappers
+  # associated with the Qt version being used.
+  set(generated_cpp_suffix "_${QT_VERSION_MAJOR}${QT_VERSION_MINOR}")
+
+  # TODO: generated headers for Qt4.8 contains several strange locales that are not available out of the box
+  #       force 4.7
+  if("${generated_cpp_suffix}" STREQUAL "_46" OR "${generated_cpp_suffix}" STREQUAL "_48")
+    set(generated_cpp_suffix "_47") # Also use 4.7 wrappers for 4.6.x version
+   endif()
+endif()
 #-----------------------------------------------------------------------------
 # Sources
 
@@ -123,8 +169,6 @@ set(sources
     src/PythonQtStdIn.cpp
     src/PythonQtStdOut.cpp
     src/gui/PythonQtScriptingConsole.cpp
-
-    generated_cpp${generated_cpp_suffix}/PythonQt_QtBindings.cpp
 
     generated_cpp${generated_cpp_suffix}/com_trolltech_qt_core_builtin/com_trolltech_qt_core_builtin0.cpp
     generated_cpp${generated_cpp_suffix}/com_trolltech_qt_core_builtin/com_trolltech_qt_core_builtin_init.cpp
@@ -157,12 +201,14 @@ set(headers
     src/PythonQtStdIn.h
     src/PythonQtStdOut.h
     src/PythonQtSystem.h
-    src/PythonQtUtils.h
     src/PythonQtVariants.h
     src/PythonQtPythonInclude.h
-    generated_cpp${generated_cpp_suffix}/PythonQt_QtBindings.h
+    src/PythonQtUtils.h
 )
-
+if(DESIRED_QT_VERSION MATCHES 4)
+  set(sources ${sources} generated_cpp${generated_cpp_suffix}/PythonQt_QtBindings.cpp)
+  set(headers ${headers} generated_cpp${generated_cpp_suffix}/PythonQt_QtBindings.h)
+endif()
 #-----------------------------------------------------------------------------
 # Headers that should run through moc
 
@@ -179,27 +225,27 @@ set(moc_sources
 #-----------------------------------------------------------------------------
 # Add extra sources
 foreach(qtlib core gui network opengl sql svg uitools webkit xml xmlpatterns)
-
+  
   if (${PythonQt_Wrap_Qt${qtlib}})
-
+    
     ADD_DEFINITIONS(-DPYTHONQT_WRAP_Qt${qtlib})
-
+    
     set(file_prefix generated_cpp${generated_cpp_suffix}/com_trolltech_qt_${qtlib}/com_trolltech_qt_${qtlib})
-
+    
     foreach(index RANGE 0 11)
-
+    
       # Source files
       if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file_prefix}${index}.cpp)
         list(APPEND sources ${file_prefix}${index}.cpp)
       endif()
-
+      
       # Headers that should run through moc
       if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file_prefix}${index}.h)
         list(APPEND moc_sources ${file_prefix}${index}.h)
       endif()
-
+      
     endforeach()
-
+    
     list(APPEND sources ${file_prefix}_init.cpp)
 
   endif()
@@ -215,17 +261,33 @@ set(qrc_sources )
 
 #-----------------------------------------------------------------------------
 # Do wrapping
-qt4_wrap_cpp(gen_moc_sources ${moc_sources})
-qt4_wrap_ui(gen_ui_sources ${ui_sources})
-qt4_add_resources(gen_qrc_sources ${qrc_sources})
+if(DESIRED_QT_VERSION MATCHES 4)
+  qt4_wrap_cpp(gen_moc_sources ${moc_sources})
+  qt4_wrap_ui(gen_ui_sources ${ui_sources})
+  qt4_add_resources(gen_qrc_sources ${qrc_sources})
+else()
+  qt5_wrap_cpp(gen_moc_sources ${moc_sources})
+  qt5_wrap_ui(gen_ui_sources ${ui_sources})
+  qt5_add_resources(gen_qrc_sources ${qrc_sources})
 
+  include_directories(${Qt5Core_INCLUDE_DIRS})
+  include_directories(${Qt5Widgets_INCLUDE_DIRS})
+  include_directories(${Network_INCLUDE_DIRS})
+  include_directories(${OpenGL_INCLUDE_DIRS})
+  include_directories(${Sql_INCLUDE_DIRS})
+  include_directories(${Svg_INCLUDE_DIRS})
+  include_directories(${WebKitWidgets_INCLUDE_DIRS})
+  include_directories(${Xml_INCLUDE_DIRS})
+  include_directories(${XmlPatterns_INCLUDE_DIRS})
+  include_directories(${UiTools_INCLUDE_DIRS})
+endif()
 #-----------------------------------------------------------------------------
 # Build the library
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/src
   )
-
+  
 add_library(PythonQt SHARED
             ${sources}
             ${gen_moc_sources}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,12 @@ if(PythonQt_QT_VERSION MATCHES 5)
   # associated with the Qt version being used.
   set(generated_cpp_suffix "_${Qt5Core_VERSION_MAJOR}${Qt5Core_VERSION_MINOR}")
 
+  # Use Qt5.4 as default for higher versions like it's done in build/common.prf
+  if(${Qt5Core_VERSION_MINOR} GREATER 4)
+    set(generated_cpp_suffix "_${Qt5Core_VERSION_MAJOR}4")
+  endif()
+
+
 else()
   #-----------------------------------------------------------------------------
   # Setup Qt4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,4 +363,3 @@ if(BUILD_TESTING)
     )
 endif()
 
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,3 +363,4 @@ if(BUILD_TESTING)
     )
 endif()
 
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,18 +352,6 @@ if(BUILD_TESTING)
       )
   endif()
 
-  if(PythonQt_Wrap_Qtcore)
-    include_directories(generated_cpp${generated_cpp_suffix})
-
-    list(APPEND test_sources
-      tests/PythonQtTestCleanup.cpp
-      tests/PythonQtTestCleanup.h
-      )
-    QT4_WRAP_CPP(test_sources
-      tests/PythonQtTestCleanup.h
-      )
-  endif()
-
   set_property(SOURCE tests/PythonQtTestMain.cpp PROPERTY COMPILE_DEFINITIONS "main=tests_PythonQtTestMain")
 
   add_executable(PythonQtCppTests ${test_sources})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ endif()
 
 option(PythonQt_Wrap_QtAll "Make all Qt components available in python" OFF)
 
-set(qtlibs core gui network opengl sql svg uitools webkit xml xmlpatterns)
 foreach(qtlib ${qtlibs})
   OPTION(PythonQt_Wrap_Qt${qtlib} "Make all of Qt${qtlib} available in python" OFF)
 endforeach()
@@ -83,6 +82,11 @@ endif()
 # Setup Qt
 
 if(PythonQt_QT_VERSION MATCHES 5)
+
+  if(BUILD_TESTING)
+    list(APPEND qtlibs Test)
+  endif()
+
   find_package(Qt5 ${minimum_required_qt5_version} COMPONENTS ${qtlibs} REQUIRED)
 
   if(Qt5_DIR)
@@ -104,6 +108,11 @@ if(PythonQt_QT_VERSION MATCHES 5)
     message(FATAL_ERROR "Could not determine Qt binary directory: ${_result} ${QT_BINARY_DIR} ${_error}")
   endif()
 
+  foreach(qtlib ${qtlibs})
+       include_directories(${Qt5${qtlib}_INCLUDE_DIRS})
+       add_definitions(${Qt5${qtlib}_DEFINITIONS})
+  endforeach()
+
   #-----------------------------------------------------------------------------
   # The variable "generated_cpp_suffix" allows to conditionnally compile the generated wrappers
   # associated with the Qt version being used.
@@ -124,7 +133,7 @@ else()
     endif()
 
     # Enable required qt module
-    foreach(qtlib network opengl sql svg uitools webkit xml xmlpatterns)
+    foreach(qtlib ${qtlibs})
       string(TOUPPER ${qtlib} qtlib_uppercase)
       if (NOT ${QT_QT${qtlib_uppercase}_FOUND})
         message(FATAL_ERROR "QT_QT${${qtlib_uppercase} *not* FOUND - Try to disable PythonQt_Wrap_Qt${qtlib}")
@@ -137,12 +146,15 @@ else()
     message(FATAL_ERROR "error: Qt4 was not found on your system. You probably need to set the QT_QMAKE_EXECUTABLE variable")
   endif()
 
+  # Enable QtTest in Qt4 is the option BUILD_TESTING was activated
+  set(QT_USE_QTTEST ${BUILD_TESTING})
+
   #-----------------------------------------------------------------------------
   # The variable "generated_cpp_suffix" allows to conditionnally compile the generated wrappers
   # associated with the Qt version being used.
   set(generated_cpp_suffix "_${QT_VERSION_MAJOR}${QT_VERSION_MINOR}")
 
-  # TODO: generated headers for Qt4.8 contains several locales that are not available 
+  # TODO: generated headers for Qt4.8 contains several locales that are not available
   #       out of the box -> force 4.7
   if("${generated_cpp_suffix}" STREQUAL "_46" OR "${generated_cpp_suffix}" STREQUAL "_48")
     set(generated_cpp_suffix "_47") # Also use 4.7 wrappers for 4.6.x version
@@ -225,28 +237,28 @@ set(moc_sources
 
 #-----------------------------------------------------------------------------
 # Add extra sources
-foreach(qtlib core gui network opengl sql svg uitools webkit xml xmlpatterns)
-  
+foreach(qtlib ${qtlibs})
+
   if (${PythonQt_Wrap_Qt${qtlib}})
-    
+
     ADD_DEFINITIONS(-DPYTHONQT_WRAP_Qt${qtlib})
-    
+
     set(file_prefix generated_cpp${generated_cpp_suffix}/com_trolltech_qt_${qtlib}/com_trolltech_qt_${qtlib})
-    
+
     foreach(index RANGE 0 11)
-    
+
       # Source files
       if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file_prefix}${index}.cpp)
         list(APPEND sources ${file_prefix}${index}.cpp)
       endif()
-      
+
       # Headers that should run through moc
       if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file_prefix}${index}.h)
         list(APPEND moc_sources ${file_prefix}${index}.h)
       endif()
-      
+
     endforeach()
-    
+
     list(APPEND sources ${file_prefix}_init.cpp)
 
   endif()
@@ -270,17 +282,6 @@ else()
   qt5_wrap_cpp(gen_moc_sources ${moc_sources})
   qt5_wrap_ui(gen_ui_sources ${ui_sources})
   qt5_add_resources(gen_qrc_sources ${qrc_sources})
-
-  include_directories(${Qt5Core_INCLUDE_DIRS})
-  include_directories(${Qt5Widgets_INCLUDE_DIRS})
-  include_directories(${Network_INCLUDE_DIRS})
-  include_directories(${OpenGL_INCLUDE_DIRS})
-  include_directories(${Sql_INCLUDE_DIRS})
-  include_directories(${Svg_INCLUDE_DIRS})
-  include_directories(${WebKitWidgets_INCLUDE_DIRS})
-  include_directories(${Xml_INCLUDE_DIRS})
-  include_directories(${XmlPatterns_INCLUDE_DIRS})
-  include_directories(${UiTools_INCLUDE_DIRS})
 endif()
 #-----------------------------------------------------------------------------
 # Build the library
@@ -288,7 +289,7 @@ endif()
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/src
   )
-  
+
 add_library(PythonQt SHARED
             ${sources}
             ${gen_moc_sources}
@@ -342,7 +343,7 @@ if(BUILD_TESTING)
     QT5_WRAP_CPP(test_sources
       tests/PythonQtTests.h
       )
-  endif() 
+  endif()
 
   set_property(SOURCE tests/PythonQtTestMain.cpp PROPERTY COMPILE_DEFINITIONS "main=tests_PythonQtTestMain")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,18 @@ if(BUILD_TESTING)
       )
   endif()
 
+  if(PythonQt_Wrap_Qtcore)
+    include_directories(generated_cpp${generated_cpp_suffix})
+
+    list(APPEND test_sources
+      tests/PythonQtTestCleanup.cpp
+      tests/PythonQtTestCleanup.h
+      )
+    QT4_WRAP_CPP(test_sources
+      tests/PythonQtTestCleanup.h
+      )
+  endif()
+
   set_property(SOURCE tests/PythonQtTestMain.cpp PROPERTY COMPILE_DEFINITIONS "main=tests_PythonQtTestMain")
 
   add_executable(PythonQtCppTests ${test_sources})

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Prerequisites
 Build instructions
 ------------------
 
-By default, the `patched-3` version will be checked out.
+By default, the `patched-5` version will be checked out.
 
 ```
 git clone git://github.com/commontk/PythonQt.git
@@ -46,7 +46,9 @@ Available branches
 This repository contains 5 branches:
 
 ### patched-5
-* Based on patched-4 + [r395](http://sourceforge.net/p/pythonqt/code/395/)
+* Based on patched-4 + [r403](http://sourceforge.net/p/pythonqt/code/403/) excluding commit [r397](http://sourceforge.net/p/pythonqt/code/397/)
+* List of bug fixes:
+ * Fix for memory leaks and cleanup crash
 * List of features:
  * CMake:
   * Fix install rules

--- a/README.md
+++ b/README.md
@@ -43,8 +43,17 @@ Additional configure options are:
 Available branches
 ------------------
 
-This repository contains three branches:
-* Based on [r245](http://sourceforge.net/p/pythonqt/code/245/)
+This repository contains 5 branches:
+
+### patched-5
+* Based on patched-4 + [r395](http://sourceforge.net/p/pythonqt/code/395/)
+* List of features:
+ * CMake:
+  * Fix install rules
+  * Fix "_invalid_parameter_noinfo_noreturn" link error
+ * PythonQt:
+  * Add Qt5 support
+  * Add PY3K support
 
 ### patched-4
 * Based on patched-3 + [r245](http://sourceforge.net/p/pythonqt/code/245/)

--- a/generator/abstractmetalang.cpp
+++ b/generator/abstractmetalang.cpp
@@ -696,18 +696,6 @@ QString AbstractMetaFunction::targetLangSignature(bool minimal) const
 
     // Attributes...
     if (!minimal) {
-#if 0 // jambi
-        if (isPublic()) s += "public ";
-        else if (isProtected()) s += "protected ";
-        else if (isPrivate()) s += "private ";
-
-//     if (isNative()) s += "native ";
-//     else
-        if (isFinalInTargetLang()) s += "final ";
-        else if (isAbstract()) s += "abstract ";
-
-        if (isStatic()) s += "static ";
-#endif
         // Return type
         if (type())
             s += type()->name() + " ";

--- a/generator/shellgenerator.cpp
+++ b/generator/shellgenerator.cpp
@@ -297,6 +297,18 @@ bool ShellGenerator::functionHasNonConstReferences(const AbstractMetaFunction* f
   return false;
 }
 
+bool ShellGenerator::functionNeedsNormalWrapperSlot(const AbstractMetaFunction* func, const AbstractMetaClass* currentClass)
+{
+  if (func->isSlot()) {
+    return false;
+  }
+  else if (func->isVirtual()) {
+    return func->declaringClass() == currentClass;
+  } else {
+    return true;
+  }
+}
+
 AbstractMetaFunctionList ShellGenerator::getFunctionsToWrap(const AbstractMetaClass* meta_class)
 {
   AbstractMetaFunctionList functions = meta_class->queryFunctions( 

--- a/generator/shellgenerator.h
+++ b/generator/shellgenerator.h
@@ -77,6 +77,8 @@ public:
 
     bool functionHasNonConstReferences(const AbstractMetaFunction* func);
 
+    bool functionNeedsNormalWrapperSlot(const AbstractMetaFunction* func, const AbstractMetaClass* currentClass);
+
     static QString shellClassName(const AbstractMetaClass *meta_class) {
       return "PythonQtShell_" + meta_class->name();
     }

--- a/generator/shellheadergenerator.cpp
+++ b/generator/shellheadergenerator.cpp
@@ -352,7 +352,7 @@ void ShellHeaderGenerator::write(QTextStream &s, const AbstractMetaClass *meta_c
   AbstractMetaFunctionList functions = getFunctionsToWrap(meta_class);
 
   foreach (const AbstractMetaFunction *function, functions) {
-    if (!function->isSlot()) {
+    if (functionNeedsNormalWrapperSlot(function, meta_class)) {
       // for debugging:
       //functionHasNonConstReferences(function);
       s << "   ";

--- a/generator/shellheadergenerator.h
+++ b/generator/shellheadergenerator.h
@@ -60,6 +60,9 @@ public:
     virtual QString fileNameForClass(const AbstractMetaClass *cls) const;
 
     void write(QTextStream &s, const AbstractMetaClass *meta_class);
+
+    void writePromoterArgs(AbstractMetaArgumentList &args, QTextStream & s);
+
     void writeInjectedCode(QTextStream &s, const AbstractMetaClass *meta_class, int type, bool recursive = false);
 
   void writeFieldAccessors(QTextStream &s, const AbstractMetaField *field);

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -294,7 +294,8 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
             s << meta_class->qualifiedCppName() << "::";
           }
         } else {
-          if (fun->wasProtected() || (fun->isVirtual() && meta_class->typeEntry()->shouldCreatePromoter())) {
+          if (fun->wasProtected()) {
+            //|| (fun->isVirtual() && meta_class->typeEntry()->shouldCreatePromoter())) {
             s << " (("  << promoterClassName(meta_class) << "*)theWrappedObject)->promoted_";
           } else {
             s << " theWrappedObject->";

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -248,7 +248,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
   // write member functions
   for (int i = 0; i < functions.size(); ++i) {
     AbstractMetaFunction *fun = functions.at(i);
-    bool needsWrapping = (!fun->isSlot() || fun->isVirtual());
+    bool needsWrapping = !fun->isSlot();
     if (!needsWrapping) {
       continue;
     }

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -248,7 +248,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
   // write member functions
   for (int i = 0; i < functions.size(); ++i) {
     AbstractMetaFunction *fun = functions.at(i);
-    bool needsWrapping = !fun->isSlot();
+    bool needsWrapping = functionNeedsNormalWrapperSlot(fun, meta_class);
     if (!needsWrapping) {
       continue;
     }

--- a/generator/typesystem_gui.xml
+++ b/generator/typesystem_gui.xml
@@ -2099,7 +2099,6 @@ PyObject* constScanLine(QImage* image, int line) {
     <modify-function signature="fontMetrics()const" remove="all"/>
     <modify-function signature="sizeHint()const" rename="getSizeHint"/>
     <modify-function signature="minimumSizeHint()const" rename="getMinimumSizeHint"/>
-    <modify-function signature="setVisible(bool)" remove="all"/>
   </object-type>
 
   <object-type name="QMessageBox">

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1294,6 +1294,10 @@ PythonQtPrivate::PythonQtPrivate()
   _hadError = false;
   _systemExitExceptionHandlerEnabled = false;
   _debugAPI = new PythonQtDebugAPI(this);
+
+  PythonQtConv::global_valueStorage.init();
+  PythonQtConv::global_ptrStorage.init();
+  PythonQtConv::global_variantStorage.init();
 }
 
 void PythonQtPrivate::setupSharedLibrarySuffixes()

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -246,6 +246,10 @@ void PythonQt::init(int flags, const QByteArray& pythonQtModuleName)
 void PythonQt::cleanup()
 {
   if (_self) {
+    // Remove signal handlers in advance, since destroying them calls back into
+    // PythonQt::priv()->removeSignalEmitter()
+    _self->removeSignalHandlers();
+
     delete _self;
     _self = NULL;
   }

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -693,6 +693,7 @@ PyObject* PythonQtPrivate::createNewPythonQtEnumWrapper(const char* enumName, Py
   PyObject* className = PyString_FromString(enumName);
 
   PyObject* baseClasses = PyTuple_New(1);
+  Py_INCREF(&PyInt_Type);
   PyTuple_SET_ITEM(baseClasses, 0, (PyObject*)&PyInt_Type);
 
   PyObject* module = PyObject_GetAttrString(parentObject, "__module__");

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -670,6 +670,7 @@ PythonQtClassWrapper* PythonQtPrivate::createNewPythonQtClassWrapper(PythonQtCla
   // create the new type object by calling the type
   result = (PythonQtClassWrapper *)PyObject_Call((PyObject *)&PythonQtClassWrapper_Type, args, NULL);
 
+  Py_DECREF(moduleName);
   Py_DECREF(baseClasses);
   Py_DECREF(typeDict);
   Py_DECREF(args);
@@ -703,6 +704,7 @@ PyObject* PythonQtPrivate::createNewPythonQtEnumWrapper(const char* enumName, Py
   // create the new int derived type object by calling the core type
   result = PyObject_Call((PyObject *)&PyType_Type, args, NULL);
 
+  Py_DECREF(module);
   Py_DECREF(baseClasses);
   Py_DECREF(typeDict);
   Py_DECREF(args);

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -657,6 +657,7 @@ PythonQtClassWrapper* PythonQtPrivate::createNewPythonQtClassWrapper(PythonQtCla
   PyObject* className = PyString_FromString(pythonClassName.constData());
 
   PyObject* baseClasses = PyTuple_New(1);
+  Py_INCREF(&PythonQtInstanceWrapper_Type);
   PyTuple_SET_ITEM(baseClasses, 0, (PyObject*)&PythonQtInstanceWrapper_Type);
 
   PyObject* typeDict = PyDict_New();
@@ -1611,6 +1612,7 @@ void PythonQt::initPythonQtModule(bool redirectStdOut, const QByteArray& pythonQ
 #endif
   _p->_pythonQtModuleName = name;
   
+  Py_INCREF(&PythonQtBoolResult_Type);
   PyModule_AddObject(_p->pythonQtModule().object(), "BoolResult", (PyObject*)&PythonQtBoolResult_Type);
   PythonQtObjectPtr sys;
   sys.setNewRef(PyImport_ImportModule("sys"));
@@ -1634,7 +1636,9 @@ void PythonQt::initPythonQtModule(bool redirectStdOut, const QByteArray& pythonQ
     Py_ssize_t old_size = PyTuple_Size(old_module_names);
     PyObject *module_names = PyTuple_New(old_size + 1);
     for (Py_ssize_t i = 0; i < old_size; i++) {
-      PyTuple_SetItem(module_names, i, PyTuple_GetItem(old_module_names, i));
+      PyObject *item = PyTuple_GetItem(old_module_names, i);
+      Py_INCREF(item);
+      PyTuple_SetItem(module_names, i, item);
     }
     PyTuple_SetItem(module_names, old_size, PyString_FromString(name.constData()));
     PyModule_AddObject(sys.object(), "builtin_module_names", module_names);

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -880,12 +880,10 @@ QVariant PythonQt::evalScript(PyObject* object, const QString& script, int start
 
 void PythonQt::evalFile(PyObject* module, const QString& filename)
 {
+  // NOTE: error checking is done by parseFile and evalCode
   PythonQtObjectPtr code = parseFile(filename);
-  clearError();
   if (code) {
     evalCode(module, code);
-  } else {
-    handleError();
   }
 }
 

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1389,6 +1389,18 @@ void PythonQtPrivate::removeSignalEmitter(QObject* obj)
   _signalReceivers.remove(obj);
 }
 
+void PythonQt::removeSignalHandlers()
+{
+  QList<PythonQtSignalReceiver*> signalReceivers = _p->_signalReceivers.values();
+
+  // just delete all signal receivers, they will remove themselves via removeSignalEmitter()
+  foreach(PythonQtSignalReceiver* receiver, signalReceivers) {
+    delete receiver;
+  }
+  // just to be sure, clear the receiver map as well
+  _p->_signalReceivers.clear();
+}
+
 namespace
 {
 //! adapted from python source file "pythonrun.c", function "handle_system_exit"

--- a/src/PythonQt.h
+++ b/src/PythonQt.h
@@ -526,7 +526,7 @@ public:
   //@{
 
   //! get access to internal data (should not be used on the public API, but is used by some C functions)
-  static PythonQtPrivate* priv() { return _self->_p; }
+  static PythonQtPrivate* priv() { return _self ? _self->_p : NULL; }
 
   //! clear all NotFound entries on all class infos, to ensure that
   //! newly loaded wrappers can add methods even when the object was wrapped by PythonQt before the wrapper was loaded

--- a/src/PythonQt.h
+++ b/src/PythonQt.h
@@ -365,6 +365,9 @@ public:
   //! remove a signal handler from the given \c signal of \c obj
   bool removeSignalHandler(QObject* obj, const char* signal, PyObject* receiver);
 
+  //! globally removes all signal handlers (connections between QObjects and Python).
+  void removeSignalHandlers();
+
   //@}
 
   //---------------------------------------------------------------------------

--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -134,6 +134,7 @@ bool PythonQtClassInfo::lookForPropertyAndCache(const char* memberName)
   const char* attributeName = memberName;
   // look for properties
   int i = _meta->indexOfProperty(attributeName);
+#ifdef PYTHONQT_SUPPORT_NAME_PROPERTY
   if (i==-1) {
     // try to map name to objectName
     if (qstrcmp(attributeName, "name")==0) {
@@ -142,6 +143,7 @@ bool PythonQtClassInfo::lookForPropertyAndCache(const char* memberName)
       i = _meta->indexOfProperty(attributeName);
     }
   }
+#endif
   if (i!=-1) {
     PythonQtMemberInfo newInfo(_meta->property(i));
     _cachedMembers.insert(attributeName, newInfo);

--- a/src/PythonQtInstanceWrapper.cpp
+++ b/src/PythonQtInstanceWrapper.cpp
@@ -118,7 +118,9 @@ static void PythonQtInstanceWrapper_deleteObject(PythonQtInstanceWrapper* self, 
 
 static void PythonQtInstanceWrapper_dealloc(PythonQtInstanceWrapper* self)
 {
-  PythonQtInstanceWrapper_deleteObject(self);
+  if (PythonQt::self()) {
+    PythonQtInstanceWrapper_deleteObject(self);
+  }
   self->_obj.~QPointer<QObject>();
   Py_TYPE(self)->tp_free((PyObject*)self);
 }

--- a/src/PythonQtInstanceWrapper.cpp
+++ b/src/PythonQtInstanceWrapper.cpp
@@ -345,7 +345,14 @@ static PyObject *PythonQtInstanceWrapper_help(PythonQtInstanceWrapper* obj)
 
 PyObject *PythonQtInstanceWrapper_delete(PythonQtInstanceWrapper * self)
 {
-  PythonQtInstanceWrapper_deleteObject(self, true);
+  PythonQtMemberInfo deleteSlot = self->classInfo()->member("py_delete");
+  if (deleteSlot._type == PythonQtMemberInfo::Slot) {
+    // call the py_delete slot instead of internal C++ destructor...
+    PyObject* resultObj = PythonQtSlotFunction_CallImpl(self->classInfo(), self->_obj, deleteSlot._slot, NULL, NULL, self->_wrappedPtr);
+    Py_XDECREF(resultObj);
+  } else {
+    PythonQtInstanceWrapper_deleteObject(self, true);
+  }
   Py_INCREF(Py_None);
   return Py_None;
 }

--- a/src/PythonQtMethodInfo.cpp
+++ b/src/PythonQtMethodInfo.cpp
@@ -401,7 +401,11 @@ QString PythonQtSlotInfo::fullSignature(bool skipReturnValue, int optionalArgsIn
     if (sig.startsWith("new_")) {
       sig = sig.mid(4);
       isConstructor = true;
-    } else if (sig.startsWith("delete_")) {
+    }
+    else if (sig.startsWith("py_q_")) {
+      sig = sig.mid(5);
+    }
+    else if (sig.startsWith("delete_")) {
       sig = sig.mid(7);
       isDestructor = true;
     } else if(sig.startsWith("static_")) {
@@ -471,6 +475,9 @@ QByteArray PythonQtSlotInfo::slotName(bool removeDecorators) const
 {
   QByteArray name = PythonQtUtils::methodName(_meta);
   if (removeDecorators) {
+    if (name.startsWith("py_q_")) {
+      name = name.mid(5);
+    } else 
     if (name.startsWith("static_")) {
       name = name.mid(7);
       int idx = name.indexOf("_");

--- a/src/PythonQtMisc.h
+++ b/src/PythonQtMisc.h
@@ -76,12 +76,25 @@ public:
   PythonQtValueStorage() {
     _chunkIdx  = 0;
     _chunkOffset = 0;
+    _currentChunk = NULL;
+  };
+
+  //! initialize memory
+  void init() {
+    assert(_currentChunk == NULL);
+    assert(_chunks.isEmpty());
+    _chunkIdx = 0;
+    _chunkOffset = 0;
     _currentChunk = new T[chunkEntries];
     _chunks.append(_currentChunk);
-  };
+  }
 
   //! clear all memory
   void clear() {
+    _chunkIdx = 0;
+    _chunkOffset = 0;
+    _currentChunk = NULL;
+
     T* chunk;
     Q_FOREACH(chunk, _chunks) {
       delete[]chunk;

--- a/src/PythonQtObjectPtr.cpp
+++ b/src/PythonQtObjectPtr.cpp
@@ -49,7 +49,7 @@ PythonQtObjectPtr::PythonQtObjectPtr(PyObject* o)
 
 PythonQtObjectPtr::~PythonQtObjectPtr()
 { 
-  if (_object) Py_DECREF(_object); 
+  if (_object && Py_IsInitialized()) Py_DECREF(_object);
 }
 
 void PythonQtObjectPtr::setNewRef(PyObject* o)

--- a/src/PythonQtSignalReceiver.cpp
+++ b/src/PythonQtSignalReceiver.cpp
@@ -213,6 +213,7 @@ bool PythonQtSignalReceiver::removeSignalHandler(const char* signal, PyObject* c
     if (callable) {
       while (i.hasNext()) {
         if (i.next().isSame(sigId, callable)) {
+          QMetaObject::disconnect(_obj, sigId, this, i.value().slotId());
           i.remove();
           foundCount++;
           break;
@@ -221,6 +222,7 @@ bool PythonQtSignalReceiver::removeSignalHandler(const char* signal, PyObject* c
     } else {
       while (i.hasNext()) {
         if (i.next().signalId() == sigId) {
+          QMetaObject::disconnect(_obj, sigId, this, i.value().slotId());
           i.remove();
           foundCount++;
         }

--- a/src/PythonQtSignalReceiver.cpp
+++ b/src/PythonQtSignalReceiver.cpp
@@ -172,7 +172,9 @@ PythonQtSignalReceiver::PythonQtSignalReceiver(QObject* obj):PythonQtSignalRecei
 
 PythonQtSignalReceiver::~PythonQtSignalReceiver()
 {
-  PythonQt::priv()->removeSignalEmitter(_obj);
+  if (PythonQt::priv()) {
+    PythonQt::priv()->removeSignalEmitter(_obj);
+  }
 }
 
 

--- a/tests/PythonQtTestCleanup.cpp
+++ b/tests/PythonQtTestCleanup.cpp
@@ -1,0 +1,69 @@
+#include "PythonQtTestCleanup.h"
+#include "PythonQt.h"
+#include "PythonQt_QtBindings.h"
+
+void PythonQtTestCleanup::initTestCase()
+{
+}
+
+void PythonQtTestCleanup::cleanupTestCase()
+{
+}
+
+void PythonQtTestCleanup::init()
+{
+  // Initialize before each test
+
+  PythonQt::init(PythonQt::IgnoreSiteModule);
+  PythonQt_init_QtBindings();
+
+  _helper = new PythonQtTestCleanupHelper();
+  PythonQtObjectPtr main = PythonQt::self()->getMainModule();
+  PythonQt::self()->addObject(main, "obj", _helper);
+}
+
+void PythonQtTestCleanup::cleanup()
+{
+  // Finalize and cleanup after each test
+
+  PythonQtObjectPtr main = PythonQt::self()->getMainModule();
+  PythonQt::self()->removeVariable(main, "obj");
+  delete _helper;
+  _helper = NULL;
+
+  if (Py_IsInitialized()) {
+    Py_Finalize();
+  }
+
+  PythonQt::cleanup();
+}
+
+void PythonQtTestCleanup::testQtEnum()
+{
+  QVERIFY(_helper->runScript(
+    "import PythonQt.QtCore\n" \
+    "x = PythonQt.QtCore.QFile.ReadOnly\n" \
+    "obj.setPassed()"
+    ));
+}
+
+void PythonQtTestCleanup::testCallQtMethodInDel()
+{
+  QVERIFY(_helper->runScript(
+    "import PythonQt.QtCore\n" \
+    "class TimerWrapper(object):\n" \
+    "  def __init__(self):\n" \
+    "    self.timer = PythonQt.QtCore.QTimer()\n" \
+    "  def __del__(self):\n" \
+    "    self.timer.setSingleShot(True)\n" \
+    "x = TimerWrapper()\n" \
+    "obj.setPassed()\n"
+    ));
+}
+
+bool PythonQtTestCleanupHelper::runScript(const char* script)
+{
+  _passed = false;
+  PyRun_SimpleString(script);
+  return _passed;
+}

--- a/tests/PythonQtTestCleanup.cpp
+++ b/tests/PythonQtTestCleanup.cpp
@@ -26,16 +26,14 @@ void PythonQtTestCleanup::cleanup()
 {
   // Finalize and cleanup after each test
 
-  PythonQtObjectPtr main = PythonQt::self()->getMainModule();
-  PythonQt::self()->removeVariable(main, "obj");
-  delete _helper;
-  _helper = NULL;
-
   if (Py_IsInitialized()) {
     Py_Finalize();
   }
 
   PythonQt::cleanup();
+
+  delete _helper;
+  _helper = NULL;
 }
 
 void PythonQtTestCleanup::testQtEnum()
@@ -59,6 +57,19 @@ void PythonQtTestCleanup::testCallQtMethodInDel()
     "x = TimerWrapper()\n" \
     "obj.setPassed()\n"
     ));
+}
+
+void PythonQtTestCleanup::testSignalReceiverCleanup()
+{
+  PythonQtObjectPtr main = PythonQt::self()->getMainModule();
+
+  // Test that PythonQtSignalReceiver is cleaned up properly,
+  // i.e. PythonQt::cleanup() doesn't segfault
+  main.evalScript(
+    "import PythonQt.QtCore\n" \
+    "timer = PythonQt.QtCore.QTimer(obj)\n" \
+    "timer.connect('destroyed()', obj.onDestroyed)\n" \
+    );
 }
 
 bool PythonQtTestCleanupHelper::runScript(const char* script)

--- a/tests/PythonQtTestCleanup.h
+++ b/tests/PythonQtTestCleanup.h
@@ -19,6 +19,7 @@ private Q_SLOTS:
 
   void testQtEnum();
   void testCallQtMethodInDel();
+  void testSignalReceiverCleanup();
 
 private:
   PythonQtTestCleanupHelper* _helper;
@@ -37,6 +38,7 @@ public:
 
 public Q_SLOTS:
   void setPassed() { _passed = true; }
+  void onDestroyed(QObject *) { }
 
 private:
   bool _passed;

--- a/tests/PythonQtTestCleanup.h
+++ b/tests/PythonQtTestCleanup.h
@@ -1,0 +1,45 @@
+#ifndef _PYTHONQTTESTCLEANUP_H
+#define _PYTHONQTTESTCLEANUP_H
+
+#include "PythonQt.h"
+#include <QtTest/QtTest>
+
+class PythonQtTestCleanupHelper;
+
+//! Test PythonQt cleanup and Python interpreter finalization
+class PythonQtTestCleanup : public QObject
+{
+  Q_OBJECT
+
+private Q_SLOTS:
+  void initTestCase();
+  void cleanupTestCase();
+  void init();
+  void cleanup();
+
+  void testQtEnum();
+  void testCallQtMethodInDel();
+
+private:
+  PythonQtTestCleanupHelper* _helper;
+};
+
+//! Test helper class
+class PythonQtTestCleanupHelper : public QObject
+{
+  Q_OBJECT
+public:
+  PythonQtTestCleanupHelper() :
+    _passed(false) {
+  };
+
+  bool runScript(const char* script);
+
+public Q_SLOTS:
+  void setPassed() { _passed = true; }
+
+private:
+  bool _passed;
+};
+
+#endif

--- a/tests/PythonQtTestMain.cpp
+++ b/tests/PythonQtTestMain.cpp
@@ -44,7 +44,7 @@
 
 #include <QApplication>
 
-int main( int argc, char **argv )
+int main(int argc, char *argv[])
 {
   QApplication qapp(argc, argv);
 

--- a/tests/PythonQtTestMain.cpp
+++ b/tests/PythonQtTestMain.cpp
@@ -41,6 +41,7 @@
 
 #include "PythonQt.h"
 #include "PythonQtTests.h"
+#include "PythonQtTestCleanup.h"
 
 #include <QApplication>
 
@@ -59,6 +60,13 @@ int main(int argc, char *argv[])
   failCount += QTest::qExec(&slotCalling, argc, argv);
 
   PythonQt::cleanup();
+
+  if (Py_IsInitialized()) {
+    Py_Finalize();
+  }
+
+  PythonQtTestCleanup cleanup;
+  failCount += QTest::qExec(&cleanup, argc, argv);
 
   if (failCount>0) {
     std::cerr << "Tests failed: " << failCount << std::endl;

--- a/tests/PythonQtTests.cpp
+++ b/tests/PythonQtTests.cpp
@@ -465,9 +465,11 @@ void PythonQtTestApi::initTestCase()
 void PythonQtTestApi::testProperties()
 {
   PythonQtObjectPtr main = PythonQt::self()->getMainModule();
+#ifdef PYTHONQT_SUPPORT_NAME_PROPERTY
   // check for name alias (for backward comp to Qt3)
   main.evalScript("obj.name = 'hello'");
   QVERIFY(QString("hello") == main.getVariable("obj.name").toString());
+#endif
 
   main.evalScript("obj.objectName = 'hello2'");
   QVERIFY(QString("hello2") == main.getVariable("obj.objectName").toString());


### PR DESCRIPTION
Added support for Qt >= 5.6 by removing Webkit dependency for higher QT versions. Changes for QT 5 builds in the CMakeLists.txt are still not integrated in the CTK patched-5 upstream and therefore builds with QT5 are not working. 
