### PR TITLE
Upstream patches r445 to r455

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 # Qt components
 set(qt5libs Core Widgets Network OpenGL Sql Svg UiTools Xml XmlPatterns)
-if(PythonQt_QT_VERSION VERSION_GREATER "4" AND "${Qt5_VERSION}" VERSION_LESS "5.6.0")
+if(PythonQt_QT_VERSION VERSION_GREATER "4")
   list(APPEND qt5libs WebKitWidgets)
 endif()
 set(qt4libs core gui network opengl sql svg uitools webkit xml xmlpatterns)

--- a/extensions/PythonQt_QtAll/PythonQt_QtAll.pro
+++ b/extensions/PythonQt_QtAll/PythonQt_QtAll.pro
@@ -1,13 +1,14 @@
 # If Qt has support for webkit, add it:
 qtHaveModule(webkit):CONFIG += PythonQtWebKit
 
-TARGET   = PythonQt_QtAll
+TARGET   = PythonQt_QtAll-Qt5-PythonXY
 TEMPLATE = lib
 
 DESTDIR    = ../../lib
 
 include ( ../../build/common.prf )  
 include ( ../../build/PythonQt.prf )  
+TARGET = $$replace(TARGET, PythonXY, Python$${PYTHON_VERSION})
 
 CONFIG += dll qt
 

--- a/generator/qtscript_masterinclude.h
+++ b/generator/qtscript_masterinclude.h
@@ -43,6 +43,12 @@
 #define Q_BYTE_ORDER Q_LITTLE_ENDIAN
 
 #define QT_NO_STL
+#define override 
+#define final
+#define QOPENGLVERSIONFUNCTIONS_H
+#define QOPENGLFUNCTIONS_H
+#define QOPENGLEXTRAFUNCTIONS_H
+
 #include <QtCore/QtCore>
 #include <QtGui/QtGui>
 #include <QtNetwork/QtNetwork>

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1955,15 +1955,31 @@ const QMetaObject* PythonQtPrivate::getDynamicMetaObject(PythonQtInstanceWrapper
   PythonQtDynamicClassInfo* info = wrapper->dynamicClassInfo();
   if (info) {
     if (!info->_dynamicMetaObject) {
-      buildDynamicMetaObject(((PythonQtClassWrapper*)Py_TYPE(wrapper)), prototypeMetaObject);
+      setupDynamicMetaObjectChain(((PythonQtClassWrapper*)Py_TYPE(wrapper)), prototypeMetaObject);
     }
     return info->_dynamicMetaObject;
   }
   return prototypeMetaObject;
 }
 
-void PythonQtPrivate::buildDynamicMetaObject(PythonQtClassWrapper* type, const QMetaObject* prototypeMetaObject)
+const QMetaObject* PythonQtPrivate::setupDynamicMetaObjectChain(PythonQtClassWrapper* type, const QMetaObject* prototypeMetaObject)
 {
+  if (!type->_dynamicClassInfo->_dynamicMetaObject) {
+    PyTypeObject*  superType = ((PyTypeObject *)type)->tp_base;
+    const QMetaObject* metaObjectOfParent = prototypeMetaObject;
+    if (((PythonQtClassWrapper*)superType)->_dynamicClassInfo) {
+      metaObjectOfParent = setupDynamicMetaObjectChain((PythonQtClassWrapper*)superType, prototypeMetaObject);
+    }
+    return buildDynamicMetaObject(type, metaObjectOfParent);
+  } else {
+    return type->_dynamicClassInfo->_dynamicMetaObject;
+  }
+}
+
+const QMetaObject* PythonQtPrivate::buildDynamicMetaObject(PythonQtClassWrapper* type, const QMetaObject* prototypeMetaObject)
+{
+  //std::cout << "creating " << ((PyTypeObject*)type)->tp_name << " derived from " << prototypeMetaObject->className() << std::endl;
+
   QMetaObjectBuilder builder;
   builder.setSuperClass(prototypeMetaObject);
   builder.setClassName(((PyTypeObject*)type)->tp_name);
@@ -2048,6 +2064,7 @@ void PythonQtPrivate::buildDynamicMetaObject(PythonQtClassWrapper* type, const Q
     // we don't need an own meta object, just use the one from our base class
     type->_dynamicClassInfo->_dynamicMetaObject = prototypeMetaObject;
   }
+  return type->_dynamicClassInfo->_dynamicMetaObject;
 }
 
 

--- a/src/PythonQt.h
+++ b/src/PythonQt.h
@@ -742,7 +742,11 @@ public:
   //! get the dynamic meta object for the given wrapper. It will contain the signals/slots that have been added in Python
   const QMetaObject* getDynamicMetaObject(PythonQtInstanceWrapper* wrapper, const QMetaObject* prototypeMetaObject);
 
-  void buildDynamicMetaObject(PythonQtClassWrapper* type, const QMetaObject* prototypeMetaObject);
+  //! recursively creates the dynamic meta object chain down to the Qt class wrapper. 
+  const QMetaObject* setupDynamicMetaObjectChain(PythonQtClassWrapper* type, const QMetaObject* prototypeMetaObject);
+
+  //! builds and returns the dynamic meta object for the given type, derived from prototypeMetaObject.
+  const QMetaObject* buildDynamicMetaObject(PythonQtClassWrapper* type, const QMetaObject* prototypeMetaObject);
 
   //! redirected from shell classes, tries to call the given meta call on the Python wrapper. 
   int handleMetaCall(QObject* object, PythonQtInstanceWrapper* wrapper, QMetaObject::Call call, int id, void** args);

--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -61,6 +61,7 @@ PythonQtClassInfo::PythonQtClassInfo() {
   _typeSlots = 0;
   _isQObject = false;
   _enumsCreated = false;
+  _richCompareDetectionDone = false;
   _searchPolymorphicHandlerOnParent = true;
   _searchRefCountCB = true;
   _refCallback = NULL;
@@ -737,14 +738,14 @@ QObject* PythonQtClassInfo::decorator()
       _decoratorProvider->setParent(PythonQt::priv());
       // setup enums early, since they might be needed by the constructor decorators:
       if (!_enumsCreated) {
-        createEnumWrappers();
+        createEnumWrappers(_decoratorProvider);
       }
       PythonQt::priv()->addDecorators(_decoratorProvider, PythonQtPrivate::ConstructorDecorator | PythonQtPrivate::DestructorDecorator);
     }
   }
   // check if enums need to be created and create them if they are not yet created
   if (!_enumsCreated) {
-    createEnumWrappers();
+    createEnumWrappers(_decoratorProvider);
   }
   return _decoratorProvider;
 }
@@ -856,18 +857,20 @@ void PythonQtClassInfo::createEnumWrappers(const QMetaObject* meta)
   }
 }
 
-void PythonQtClassInfo::createEnumWrappers()
+void PythonQtClassInfo::createEnumWrappers(const QObject* decoratorProvider)
 {
   if (!_enumsCreated) {
     _enumsCreated = true;
     if (_meta) {
       createEnumWrappers(_meta);
     }
-    if (decorator()) {
-      createEnumWrappers(decorator()->metaObject());
+    if (decoratorProvider) {
+      createEnumWrappers(decoratorProvider->metaObject());
     }
     Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
-      info._parent->createEnumWrappers();
+      // trigger decorator() instead of createEnumWrappers(),
+      // which will then call createEnumWrappers().
+      info._parent->decorator();
     }
   }
 }
@@ -875,7 +878,9 @@ void PythonQtClassInfo::createEnumWrappers()
 PyObject* PythonQtClassInfo::findEnumWrapper(const char* name) {
   // force enum creation
   if (!_enumsCreated) {
-    createEnumWrappers();
+    // trigger decorator() instead of createEnumWrappers(),
+    // which will then call createEnumWrappers().
+    decorator();
   }
   Q_FOREACH(const PythonQtObjectPtr& p, _enumWrappers) {
     const char* className = ((PyTypeObject*)p.object())->tp_name;
@@ -1029,11 +1034,42 @@ PythonQtClassInfo* PythonQtClassInfo::getClassInfoForProperty( const QString& na
     }
   }
   if (!typeName.isEmpty()) {
+    if (typeName.endsWith("*")) {
+      typeName.truncate(typeName.length() - 1);
+    }
     PythonQtClassInfo* classInfo = PythonQt::priv()->getClassInfo(typeName);
     return classInfo;
   }
   return NULL;
 }
+
+bool PythonQtClassInfo::supportsRichCompare()
+{
+  if (_typeSlots & PythonQt::Type_RichCompare) {
+    return true;
+  }
+  if (!_richCompareDetectionDone) {
+    _richCompareDetectionDone = true;
+    static QList<QByteArray> names;
+    if (names.isEmpty()) {
+      names << "__eq__";
+      names << "__ne__";
+      names << "__lt__";
+      names << "__le__";
+      names << "__gt__";
+      names << "__ge__";
+    }
+    foreach (const QByteArray& name, names) {
+      if (member(name)._type == PythonQtMemberInfo::Slot) {
+        // we found one of the operators, so we can support the type slot
+        _typeSlots |= PythonQt::Type_RichCompare;
+        break;
+      }
+    }
+  }
+  return (_typeSlots & PythonQt::Type_RichCompare);
+}
+
 //-------------------------------------------------------------------------
 
 PythonQtMemberInfo::PythonQtMemberInfo( PythonQtSlotInfo* info )

--- a/src/PythonQtClassInfo.h
+++ b/src/PythonQtClassInfo.h
@@ -185,7 +185,7 @@ public:
   void setShellSetInstanceWrapperCB(PythonQtShellSetInstanceWrapperCB* cb) {
     _shellSetInstanceWrapperCB = cb;
   }
-
+  
   //! get the shell set instance wrapper cb
   PythonQtShellSetInstanceWrapperCB* shellSetInstanceWrapperCB() {
     return _shellSetInstanceWrapperCB;
@@ -230,10 +230,16 @@ public:
   //! Returns the class info for given property, if available.
   PythonQtClassInfo* getClassInfoForProperty( const QString& name );
 
+  //! Returns if the class supports rich compare. This tests for
+  //! __eq__, __ne__, __lt__, __le__, __gt__, __ge__ slots and if
+  //! any of the slots is present it returns true and modifies the
+  //! _typeSlots with Type_RichCompare. The result is cached internally.
+  bool supportsRichCompare();
+
 private:
   void updateRefCountingCBs();
 
-  void createEnumWrappers();
+  void createEnumWrappers(const QObject* decoratorProvider);
   void createEnumWrappers(const QMetaObject* meta);
   PyObject* findEnumWrapper(const char* name);
 
@@ -289,6 +295,7 @@ private:
 
   bool _isQObject;
   bool _enumsCreated;
+  bool _richCompareDetectionDone;
   bool _searchPolymorphicHandlerOnParent;
   bool _searchRefCountCB;
   

--- a/src/PythonQtConversion.h
+++ b/src/PythonQtConversion.h
@@ -52,6 +52,7 @@
 
 typedef PyObject* PythonQtConvertMetaTypeToPythonCB(const void* inObject, int metaTypeId);
 typedef bool PythonQtConvertPythonToMetaTypeCB(PyObject* inObject, void* outObject, int metaTypeId, bool strict);
+typedef QVariant PythonQtConvertPythonSequenceToQVariantListCB(PyObject* inObject);
 
 #define PythonQtRegisterListTemplateConverter(type, innertype) \
 { int typeId = qRegisterMetaType<type<innertype > >(#type"<"#innertype">"); \
@@ -164,6 +165,10 @@ public:
   //! register a converter callback from cpp to python for given metatype
   static void registerMetaTypeToPythonConverter(int metaTypeId, PythonQtConvertMetaTypeToPythonCB* cb) { _metaTypeToPythonConverters.insert(metaTypeId, cb); }
 
+  //! set a callback that is called when a Python sequence should be converted to a QVariantList
+  //! to allow special conversion.
+  static void setPythonSequenceToQVariantListCallback(PythonQtConvertPythonSequenceToQVariantListCB* cb) { _pythonSequenceToQVariantListCB = cb; }
+
   //! converts the Qt parameter given in \c data, interpreting it as a \c type registered qvariant/meta type, into a Python object,
   static PyObject* convertQtValueToPythonInternal(int type, const void* data);
 
@@ -194,6 +199,7 @@ public:
 protected:
   static QHash<int, PythonQtConvertMetaTypeToPythonCB*> _metaTypeToPythonConverters; 
   static QHash<int, PythonQtConvertPythonToMetaTypeCB*> _pythonToMetaTypeConverters; 
+  static PythonQtConvertPythonSequenceToQVariantListCB*  _pythonSequenceToQVariantListCB;
  
   //! handle automatic conversion of some special types (QColor, QBrush, ...)
   static void* handlePythonToQtAutoConversion(int typeId, PyObject* obj, void* alreadyAllocatedCPPObject);

--- a/src/PythonQtSignalReceiver.cpp
+++ b/src/PythonQtSignalReceiver.cpp
@@ -109,6 +109,11 @@ PyObject* PythonQtSignalTarget::call(PyObject* callable, const PythonQtMethodInf
   for (int i = 1; i < count; i++) {
     const PythonQtMethodInfo::ParameterInfo& param = params.at(i);
     PyObject* arg = PythonQtConv::ConvertQtValueToPython(param, arguments[i]);
+    if (arg && (param.pointerCount == 1) && (param.name == "PyObject")) {
+      // ConvertQtValueToPython does not ref-count the PyObject, so we have to
+      // do it ourselves...
+      Py_INCREF(arg);
+    }
     if (arg) {
       // steals reference, no unref
       PyTuple_SetItem(pargs, i-1,arg);

--- a/src/PythonQtStdOut.cpp
+++ b/src/PythonQtStdOut.cpp
@@ -47,6 +47,7 @@ static PyObject *PythonQtStdOutRedirect_new(PyTypeObject *type, PyObject * /*arg
   self = (PythonQtStdOutRedirect *)type->tp_alloc(type, 0);
 
   self->softspace = 0;
+  self->closed = false;
   self->_cb = NULL;
 
   return (PyObject *)self;
@@ -116,6 +117,9 @@ static PyMethodDef PythonQtStdOutRedirect_methods[] = {
 static PyMemberDef PythonQtStdOutRedirect_members[] = {
   {const_cast<char*>("softspace"), T_INT, offsetof(PythonQtStdOutRedirect, softspace), 0,
     const_cast<char*>("soft space flag")
+  },
+  { const_cast<char*>("closed"), T_BOOL, offsetof(PythonQtStdOutRedirect, closed), 0,
+  const_cast<char*>("soft space flag")
   },
   {NULL}  /* Sentinel */
 };

--- a/src/PythonQtStdOut.h
+++ b/src/PythonQtStdOut.h
@@ -59,6 +59,7 @@ typedef struct {
   PyObject_HEAD
   PythonQtOutputChangedCB* _cb;
   int softspace;
+  bool closed;
 } PythonQtStdOutRedirect;
 
 #endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -4,7 +4,7 @@
 # $Source$
 # --------------------------------------------------
 
-TARGET   = PythonQt
+TARGET   = PythonQt-Qt5-PythonXY
 TEMPLATE = lib
 
 
@@ -22,6 +22,8 @@ isEmpty(PYTHONQT_STATIC) {
   CONFIG += static
 }
 
+DEFINES += PYTHONQT_CATCH_ALL_EXCEPTIONS
+
 contains(QT_MAJOR_VERSION, 5) {
   QT += widgets core-private
 }
@@ -33,6 +35,7 @@ INCLUDEPATH += $$PWD
 
 include ( ../build/common.prf )  
 include ( ../build/python.prf )
+TARGET = $$replace(TARGET, PythonXY, Python$${PYTHON_VERSION})
 
 include ( src.pri )  
 


### PR DESCRIPTION
These patches against patched-7 which contains up to r443.
Upstream r444 was not applied (considered a reversal) i.e. patched-7 already includes it.
Signed-off-by: Christoph Willing <chris.willing@linux.com>