### PR TITLE
Fix compile error on MSVC with Qt 5.7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,10 @@ set_target_properties(PythonQt  PROPERTIES
   INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
   )
 
+target_compile_options(PythonQt PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
+  )
+
 target_link_libraries(PythonQt
               ${PYTHON_LIBRARY}
               ${QT_LIBRARIES}


### PR DESCRIPTION
Fix the following compile error seen on MSVC with Qt 5.7.1 when building in
Debug configuration:

    PythonQt\src\PythonQt.cpp : fatal error C1128: number of sections exceeded object file format limit : compile with /bigobj

Extracted from https://github.com/commontk/PythonQt/pull/56/commits/3dfe45d,
authored by Stefan Dinkelacker <s.dinkelacker@dkfz-heidelberg.de>.