### PR TITLE
Remove INSTALL_NAME_DIR target property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,14 +309,6 @@ add_library(PythonQt SHARED
   )
 set_target_properties(PythonQt PROPERTIES DEFINE_SYMBOL PYTHONQT_EXPORTS)
 
-#
-# That should solve linkage error on Mac when the project is used in a superbuild setup
-# See http://blog.onesadcookie.com/2008/01/installname-magic.html
-#
-set_target_properties(PythonQt  PROPERTIES
-  INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
-  )
-
 target_compile_options(PythonQt PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
   )


### PR DESCRIPTION
Using INSTALL_NAME_DIR target property forces the install name to be an
absolute path instead of `@rpath/{target_name}` [1]. This causes problems
when one tries to relocate the target once it is installed.
This patch removes this target property. If a project needs to keep
the absolute path, CMake variables such as INSTALL_NAME_DIR can be set at
configuration to do so.

[1] https://gitlab.kitware.com/cmake/cmake/issues/16589