### PR TITLE
Install ScriptingConsole and add CMake option PythonQt_extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,7 @@ install(TARGETS PythonQt
 install(FILES ${headers} DESTINATION ${PythonQt_INSTALL_INCLUDE_DIR})
 install(FILES ${headers_gui} DESTINATION ${PythonQt_INSTALL_INCLUDE_DIR}/gui)
 
+add_subdirectory(extensions)
 #-----------------------------------------------------------------------------
 # Testing
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,9 @@ set(headers
     src/PythonQtPythonInclude.h
     generated_cpp${generated_cpp_suffix}/PythonQt_QtBindings.h
 )
+set(headers_gui
+    src/gui/PythonQtScriptingConsole.h
+)
 
 #-----------------------------------------------------------------------------
 # Headers that should run through moc
@@ -355,6 +358,7 @@ install(TARGETS PythonQt
         LIBRARY DESTINATION ${PythonQt_INSTALL_LIBRARY_DIR}
         ARCHIVE DESTINATION ${PythonQt_INSTALL_ARCHIVE_DIR})
 install(FILES ${headers} DESTINATION ${PythonQt_INSTALL_INCLUDE_DIR})
+install(FILES ${headers_gui} DESTINATION ${PythonQt_INSTALL_INCLUDE_DIR}/gui)
 
 #-----------------------------------------------------------------------------
 # Testing

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -1,0 +1,23 @@
+option(PythonQt_Extensions "Build PythonQt extensions." OFF)
+
+if(PythonQt_Extensions)
+  if(NOT PythonQt_Wrap_QtAll)
+    MESSAGE(FATAL_ERROR "Cannot build PythonQt_QtAll without PythonQt_Wrap_QtAll set to ON")
+  endif(NOT PythonQt_Wrap_QtAll)
+  set(qtall_headers
+    PythonQt_QtAll/PythonQt_QtAll.h)
+
+  set(qtall_sources
+    PythonQt_QtAll/PythonQt_QtAll.cpp)
+
+  include_directories(generated_cpp${generated_cpp_suffix})
+
+  add_library(PythonQt_QtAll SHARED ${qtall_sources})
+  target_link_libraries(PythonQt_QtAll PythonQt)
+
+  install(TARGETS PythonQt_QtAll
+    RUNTIME DESTINATION ${PythonQt_INSTALL_RUNTIME_DIR}
+    LIBRARY DESTINATION ${PythonQt_INSTALL_LIBRARY_DIR}
+    ARCHIVE DESTINATION ${PythonQt_INSTALL_ARCHIVE_DIR})
+  install(FILES ${qtall_headers} DESTINATION ${PythonQt_INSTALL_INCLUDE_DIR})
+endif()

--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -287,7 +287,7 @@ bool PythonQtClassInfo::lookForEnumAndCache(const QMetaObject* meta, const char*
           PythonQtMemberInfo newInfo(enumValuePtr);
           _cachedMembers.insert(memberName, newInfo);
   #ifdef PYTHONQT_DEBUG
-          std::cout << "caching enum " << memberName << " on " << meta->className()->constData() << std::endl;
+          std::cout << "caching enum " << memberName << " on " << meta->className() << std::endl;
   #endif
           found = true;
           break;

--- a/src/PythonQtMethodInfo.cpp
+++ b/src/PythonQtMethodInfo.cpp
@@ -50,7 +50,7 @@ QHash<QByteArray, QByteArray> PythonQtMethodInfo::_parameterNameAliases;
 PythonQtMethodInfo::PythonQtMethodInfo(const QMetaMethod& meta, PythonQtClassInfo* classInfo)
 {
 #ifdef PYTHONQT_DEBUG
-  QByteArray sig = PythonQtUtils::signature(meta));
+  QByteArray sig = PythonQtUtils::signature(meta);
   sig = sig.mid(sig.indexOf('('));
   QByteArray fullSig = QByteArray(meta.typeName()) + " " + sig;
   std::cout << "caching " << fullSig.data() << std::endl;

--- a/src/PythonQtSlot.cpp
+++ b/src/PythonQtSlot.cpp
@@ -333,7 +333,7 @@ PyObject *PythonQtSlotFunction_CallImpl(PythonQtClassInfo* classInfo, QObject* o
   }
 
 #ifdef PYTHONQT_DEBUG
-  std::cout << "called " << info->metaMethod()->typeName() << " " << info->signature() << std::endl;
+  std::cout << "called " << info->metaMethod()->typeName() << " " << info->signature().constData() << std::endl;
 #endif
 
   PyObject* r = NULL;


### PR DESCRIPTION
- Install `src/gui/PythonQtScriptingConsole.h` to `${PythonQt_INSTALL_INCLUDE_DIR}/gui/PythonQtScriptingConsole.h`
- Add option `PythonQt_extensions` in CMake to build and install PythonQt_QtAll extension.

Related to #40 and https://github.com/commontk/PythonQt/issues/47#issuecomment-225734690