### PR TITLE
ENH: added sanity checks for compatibility with pyqtgraph

### DIFF
--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -169,7 +169,8 @@ PythonQtSlotInfo* PythonQtClassInfo::recursiveFindDecoratorSlotsFromDecoratorPro
 {
   inputInfo = findDecoratorSlotsFromDecoratorProvider(memberName, inputInfo, found, memberCache, upcastingOffset);
   Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
-    inputInfo = info._parent->recursiveFindDecoratorSlotsFromDecoratorProvider(memberName, inputInfo, found, memberCache, upcastingOffset+info._upcastingOffset);
+	if (this != info._parent)
+		inputInfo = info._parent->recursiveFindDecoratorSlotsFromDecoratorProvider(memberName, inputInfo, found, memberCache, upcastingOffset+info._upcastingOffset);
   }
   return inputInfo;
 }
@@ -385,14 +386,16 @@ void PythonQtClassInfo::recursiveCollectDecoratorObjects(QList<QObject*>& decora
     decoratorObjects.append(deco);
   }
   Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
-    info._parent->recursiveCollectDecoratorObjects(decoratorObjects);
+	if (this != info._parent)
+		info._parent->recursiveCollectDecoratorObjects(decoratorObjects);
   }
 }
 
 void PythonQtClassInfo::recursiveCollectClassInfos(QList<PythonQtClassInfo*>& classInfoObjects) {
   classInfoObjects.append(this);
   Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
-    info._parent->recursiveCollectClassInfos(classInfoObjects);
+	if (this != info._parent)
+      info._parent->recursiveCollectClassInfos(classInfoObjects);
   }
 }
 
@@ -584,7 +587,7 @@ bool PythonQtClassInfo::inherits(const char* name)
     return true;
   }
   Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
-    if (info._parent->inherits(name)) {
+    if (info._parent != this && info._parent->inherits(name)) {
       return true;
     }
   }
@@ -597,7 +600,7 @@ bool PythonQtClassInfo::inherits(PythonQtClassInfo* classInfo)
     return true;
   }
   Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
-    if (info._parent->inherits(classInfo)) {
+    if (info._parent != this && info._parent->inherits(classInfo)) {
       return true;
     }
   }
@@ -761,8 +764,10 @@ void* PythonQtClassInfo::recursiveCastDownIfPossible(void* ptr, const char** res
     }
   }
   Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
+    void* resultPtr = NULL;
     if (!info._parent->isQObject()) {
-      void* resultPtr = info._parent->recursiveCastDownIfPossible((char*)ptr + info._upcastingOffset, resultClassName);
+	  if (this != info._parent)
+	    resultPtr = info._parent->recursiveCastDownIfPossible((char*)ptr + info._upcastingOffset, resultClassName);
       if (resultPtr) {
         return resultPtr;
       }
@@ -870,7 +875,8 @@ void PythonQtClassInfo::createEnumWrappers(const QObject* decoratorProvider)
     Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
       // trigger decorator() instead of createEnumWrappers(),
       // which will then call createEnumWrappers().
-      info._parent->decorator();
+	  if (info._parent != this)
+		info._parent->decorator();
     }
   }
 }
@@ -889,7 +895,9 @@ PyObject* PythonQtClassInfo::findEnumWrapper(const char* name) {
     }
   }
   Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
-    PyObject* p = info._parent->findEnumWrapper(name);
+    PyObject* p =  NULL;
+	if (info._parent != this)
+	  p = info._parent->findEnumWrapper(name);
     if (p) return p;
   }
   return NULL;
@@ -1004,6 +1012,9 @@ void PythonQtClassInfo::updateRefCountingCBs()
     if (!_parentClasses.isEmpty()) {
       // we only search in single inheritance, using the first parent class
       PythonQtClassInfo* parent = _parentClasses.at(0)._parent;
+	  if (parent == this)
+		  _searchRefCountCB = false;
+		  return;
       parent->updateRefCountingCBs();
       // propagate to ourself
       _refCallback = parent->_refCallback; 


### PR DESCRIPTION
Hi guys, I've come back to this issue https://discourse.slicer.org/t/pythonqt-properties-shadowing-methods/16992

Turns out a GraphicsScene of pyqtgraph was referencing itself as a parent when wrapped by PythonQt. I don't know if it is a bug of pyqtgraph or PythonQt. All I know is that adding this simple sanity checks prevented stack overflows and now I have pretty pyqtgraphs integrated into a PythonQt app (3D Slicer) via wrapping a pythonqt layout with shiboken2 and adding a pyside2 widget to it. More details on referenced thread.

I don't know if it is a desirable merge but it is simple enough that I figured it could be of interest.