### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -2422,22 +2422,23 @@ QString PythonQtPrivate::getSignature(PyObject* object)
       //       inspect.getargs() can handle anonymous (tuple) arguments, while this code does not.
       //       It can be implemented, but it may be rarely needed and not necessary.
       PyCodeObject* code = (PyCodeObject*)func->func_code;
-      if (code->co_varnames) {
+      PyObject* co_varnames = PyCode_GetVarnames(code);
+      if (co_varnames) {
         int nargs = code->co_argcount;
-        Q_ASSERT(PyTuple_Check(code->co_varnames));
+        Q_ASSERT(PyTuple_Check(co_varnames));
         for (int i=0; i<nargs; i++) {
-          PyObject* name = PyTuple_GetItem(code->co_varnames, i);
+          PyObject* name = PyTuple_GetItem(co_varnames, i);
           Q_ASSERT(PyString_Check(name));
           arguments << PyString_AsString(name);
         }
         if (code->co_flags & CO_VARARGS) {
-          PyObject* s = PyTuple_GetItem(code->co_varnames, nargs);
+          PyObject* s = PyTuple_GetItem(co_varnames, nargs);
           Q_ASSERT(PyString_Check(s));
           varargs = PyString_AsString(s);
           nargs += 1;
         }
         if (code->co_flags & CO_VARKEYWORDS) {
-          PyObject* s = PyTuple_GetItem(code->co_varnames, nargs);
+          PyObject* s = PyTuple_GetItem(co_varnames, nargs);
           Q_ASSERT(PyString_Check(s));
           varkeywords = PyString_AsString(s);
         }

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -58,7 +58,6 @@
 
 #include <QDir>
 
-#include <pydebug.h>
 #include <vector>
 
 PythonQt* PythonQt::_self = NULL;

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -2422,7 +2422,11 @@ QString PythonQtPrivate::getSignature(PyObject* object)
       //       inspect.getargs() can handle anonymous (tuple) arguments, while this code does not.
       //       It can be implemented, but it may be rarely needed and not necessary.
       PyCodeObject* code = (PyCodeObject*)func->func_code;
+#if PY_VERSION_HEX < (3 << 24 | 11 << 16)
+      PyObject* co_varnames = code->co_varnames;
+#else
       PyObject* co_varnames = PyCode_GetVarnames(code);
+#endif
       if (co_varnames) {
         int nargs = code->co_argcount;
         Q_ASSERT(PyTuple_Check(co_varnames));

--- a/src/PythonQtClassWrapper.h
+++ b/src/PythonQtClassWrapper.h
@@ -49,7 +49,6 @@
 #include "structmember.h"
 #include "methodobject.h"
 #include "compile.h"
-#include "eval.h"
 #include <QString>
 
 class PythonQtClassInfo;

--- a/src/PythonQtInstanceWrapper.h
+++ b/src/PythonQtInstanceWrapper.h
@@ -51,7 +51,6 @@
 #include "structmember.h"
 #include "methodobject.h"
 #include "compile.h"
-#include "eval.h"
 
 class PythonQtClassInfo;
 class QObject;

--- a/src/PythonQtSignalReceiver.cpp
+++ b/src/PythonQtSignalReceiver.cpp
@@ -45,7 +45,6 @@
 #include "PythonQtConversion.h"
 #include <QMetaObject>
 #include <QMetaMethod>
-#include "funcobject.h"
 
 // use -2 to signal that the variable is uninitialized
 int PythonQtSignalReceiver::_destroyedSignal1Id = -2;


### PR DESCRIPTION
The location of pydebug.h, which is included in PythonQt.cpp, changed in Python 3.10 but it is not used anyway, so remove it to stay compatible w/ all Python versions w/o any preprocessor switches.