### PR TITLE
[commontk] Revert part of r91 preventing QFlags from being wrapped

### DIFF
--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -289,10 +289,12 @@ bool PythonQtClassInfo::lookForEnumAndCache(const QMetaObject* meta, const char*
   int enumCount = meta->enumeratorCount();
   for (int i = 0; i < enumCount; i++) {
     QMetaEnum e = meta->enumerator(i);
-    // we do not want flags, they will cause our values to appear two times
-    if (e.isFlag())
+    if (_cachedMembers.contains(memberName)) {
+#ifdef PYTHONQT_DEBUG
+      std::cout << "cached enum " << memberName << " on " << meta->className() << std::endl;
+#endif
       continue;
-
+    }
     for (int j = 0; j < e.keyCount(); j++) {
       if (escapeReservedNames(e.key(j)) == memberName) {
         PyObject* enumType = findEnumWrapper(e.name());
@@ -558,9 +560,6 @@ QStringList PythonQtClassInfo::memberList()
     for (int i = 0; i < meta->enumeratorCount(); i++) {
       QMetaEnum e = meta->enumerator(i);
       l << e.name();
-      // we do not want flags, they will cause our values to appear two times
-      if (e.isFlag())
-        continue;
 
       for (int j = 0; j < e.keyCount(); j++) {
         l << QString(e.key(j));

--- a/tests/PythonQtTests.cpp
+++ b/tests/PythonQtTests.cpp
@@ -393,6 +393,24 @@ void PythonQtTestSlotCalling::testCppFactory()
   QVERIFY(_helper->runScript(
     "obj.testNoArg()\nfrom PythonQt.private import PQCppObject2\na = PQCppObject2()\nif "
     "a.testEnumFlag3(PQCppObject2.TestEnumValue2)==PQCppObject2.TestEnumValue2: obj.setPassed();\n"));
+
+  PythonQt::self()->registerCPPClass("PQCppObjectQFlagOnly", NULL, NULL,
+    PythonQtCreateObject<PQCppObjectQFlagOnlyDecorator>);
+
+  // local enum (decorated)
+  QVERIFY(_helper->runScript(
+    "obj.testNoArg()\nfrom PythonQt.private import PQCppObjectQFlagOnly\na = PQCppObjectQFlagOnly()\nprint "
+    "(a.testEnumFlag1)\nif a.testEnumFlag1(PQCppObjectQFlagOnly.TestEnumValue2)==PQCppObjectQFlagOnly.TestEnumValue2: "
+    "obj.setPassed();\n"));
+
+  // enum with namespace (decorated)
+  QVERIFY(_helper->runScript(
+    "obj.testNoArg()\nfrom PythonQt.private import PQCppObjectQFlagOnly\na = PQCppObjectQFlagOnly()\nif "
+    "a.testEnumFlag2(PQCppObjectQFlagOnly.TestEnumValue2)==PQCppObjectQFlagOnly.TestEnumValue2: obj.setPassed();\n"));
+  // with int overload to check overloading
+  QVERIFY(_helper->runScript(
+    "obj.testNoArg()\nfrom PythonQt.private import PQCppObjectQFlagOnly\na = PQCppObjectQFlagOnly()\nif "
+    "a.testEnumFlag3(PQCppObjectQFlagOnly.TestEnumValue2)==PQCppObjectQFlagOnly.TestEnumValue2: obj.setPassed();\n"));
 }
 
 PQCppObject2Decorator::TestEnumFlag PQCppObject2Decorator::testEnumFlag1(PQCppObject2* /*obj*/,
@@ -416,6 +434,34 @@ PQCppObject2Decorator::TestEnumFlag PQCppObject2Decorator::testEnumFlag3(PQCppOb
 {
   return flag;
 }
+
+// PQCppObjectQFlagOnlyDecorator
+
+PQCppObjectQFlagOnlyDecorator::TestEnumFlag PQCppObjectQFlagOnlyDecorator::testEnumFlag1(PQCppObjectQFlagOnly* obj,
+  PQCppObjectQFlagOnlyDecorator::TestEnumFlag flag)
+{
+  return flag;
+}
+
+PQCppObjectQFlagOnly::TestEnumFlag PQCppObjectQFlagOnlyDecorator::testEnumFlag2(PQCppObjectQFlagOnly* obj,
+  PQCppObjectQFlagOnly::TestEnumFlag flag)
+{
+  return flag;
+}
+
+// with int overload
+PQCppObjectQFlagOnlyDecorator::TestEnumFlag PQCppObjectQFlagOnlyDecorator::testEnumFlag3(PQCppObjectQFlagOnly* obj,
+  int flag)
+{
+  return (TestEnumFlag)-1;
+}
+PQCppObjectQFlagOnlyDecorator::TestEnumFlag PQCppObjectQFlagOnlyDecorator::testEnumFlag3(PQCppObjectQFlagOnly* obj,
+  PQCppObjectQFlagOnlyDecorator::TestEnumFlag flag)
+{
+  return flag;
+}
+
+// PythonQtTestSlotCalling
 
 void PythonQtTestSlotCalling::testMultiArgsSlotCall()
 {

--- a/tests/PythonQtTests.h
+++ b/tests/PythonQtTests.h
@@ -298,6 +298,31 @@ public Q_SLOTS:
   TestEnumFlag testEnumFlag3(PQCppObject2* obj, TestEnumFlag flag);
 };
 
+typedef PQCppObject2 PQCppObjectQFlagOnly;
+
+class PQCppObjectQFlagOnlyDecorator : public QObject
+{
+  Q_OBJECT
+
+public:
+  Q_FLAGS(TestEnumFlag)
+
+  enum TestEnumFlag { TestEnumValue1 = 0, TestEnumValue2 = 1 };
+
+  Q_DECLARE_FLAGS(TestEnum, TestEnumFlag)
+
+public slots:
+  PQCppObjectQFlagOnly* new_PQCppObjectQFlagOnly() { return new PQCppObjectQFlagOnly(); }
+
+  TestEnumFlag testEnumFlag1(PQCppObjectQFlagOnly* obj, TestEnumFlag flag);
+
+  PQCppObjectQFlagOnly::TestEnumFlag testEnumFlag2(PQCppObjectQFlagOnly* obj, PQCppObjectQFlagOnly::TestEnumFlag flag);
+
+  // with int overload
+  TestEnumFlag testEnumFlag3(PQCppObjectQFlagOnly* obj, int flag);
+  TestEnumFlag testEnumFlag3(PQCppObjectQFlagOnly* obj, TestEnumFlag flag);
+};
+
 class PQUnknownValueObject
 {
 public:


### PR DESCRIPTION
The commit https://github.com/commontk/PythonQt/commit/86068fdc0534b18e0ff04abb109811eca1be7d52 was accidentally missed during creation of this `patched-v3.6.1-2025-12-22-469f01f6a` and was not carried over. Likely due to mishandling of batch cherry-picking not being inclusive of the git hash set to start the range.

---------------------
By checking if an enum member has already been cached it is not required anymore to skip it if is a QFlags.

Additionally, the wrapping of QFlags can now be done by using only Q_FLAGS without having a corresponding Q_ENUMS.

Cherry-picked from https://github.com/commontk/PythonQt/commit/86068fdc0534b18e0ff04abb109811eca1be7d52